### PR TITLE
Fix mobile layout (managers, hall of fame) + relative draft grades

### DIFF
--- a/web/src/lib/components/DraftAnalysis.svelte
+++ b/web/src/lib/components/DraftAnalysis.svelte
@@ -9,6 +9,33 @@
 		if (grade.startsWith('D')) return 'text-orange-400';
 		return 'text-red-400';
 	}
+
+	// Grade each manager's draft on the season's own curve. Absolute thresholds make
+	// everyone an "A" (a full-season player naturally scores 100+), so grade by how far
+	// a manager's avg points/pick sits from the season mean (z-score across managers).
+	$: gradeByManager = computeGrades(analytics?.managerPerformance ?? []);
+	function computeGrades(mgrs: any[]): Record<string, string> {
+		const out: Record<string, string> = {};
+		const vals = mgrs
+			.map((m: any) => parseFloat(m.avgPointsPerPick || 0))
+			.filter((v: number) => v > 0);
+		if (!vals.length) return out;
+		const mean = vals.reduce((a: number, b: number) => a + b, 0) / vals.length;
+		const sd = Math.sqrt(vals.reduce((a: number, b: number) => a + (b - mean) ** 2, 0) / vals.length);
+		const gradeOf = (v: number) => {
+			if (sd === 0) return 'B';
+			const z = (v - mean) / sd;
+			if (z >= 1.0) return 'A';
+			if (z >= 0.3) return 'B';
+			if (z >= -0.3) return 'C';
+			if (z >= -1.0) return 'D';
+			return 'F';
+		};
+		mgrs.forEach((m: any) => {
+			out[m.managerName] = gradeOf(parseFloat(m.avgPointsPerPick || 0));
+		});
+		return out;
+	}
 </script>
 
 {#if analytics}
@@ -64,7 +91,7 @@
 				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 					{#each analytics.managerPerformance.slice(0, 9) as manager}
 						{@const avgPoints = parseFloat(manager.avgPointsPerPick || 0)}
-						{@const grade = avgPoints >= 100 ? 'A' : avgPoints >= 80 ? 'B' : avgPoints >= 60 ? 'C' : 'D'}
+						{@const grade = gradeByManager[manager.managerName] ?? 'C'}
 						<div class="bg-slate-700/30 rounded-lg p-4">
 							<div class="flex items-center justify-between mb-3">
 								<span class="font-bold text-white">{manager.managerName}</span>

--- a/web/src/routes/hall-of-fame/+page.svelte
+++ b/web/src/routes/hall-of-fame/+page.svelte
@@ -231,10 +231,10 @@
 			<div class="space-y-3">
 				{#each managers as manager, index}
 					<div class="bg-gradient-to-r {getTierColor(manager.hallOfFameRank)} p-[1px] rounded-xl">
-						<div class="bg-slate-800 rounded-xl p-6">
-							<div class="flex items-center justify-between">
+						<div class="bg-slate-800 rounded-xl p-4 sm:p-6">
+							<div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
 								<!-- Left Side: Rank and Manager Info -->
-								<div class="flex items-center space-x-4">
+								<div class="flex items-center space-x-4 min-w-0">
 									<div class="flex-shrink-0 text-center">
 										<div class="text-3xl font-bold text-white">#{manager.hallOfFameRank}</div>
 										<div class="text-lg">{getTierBadge(manager.hallOfFameRank)}</div>

--- a/web/src/routes/managers/+page.svelte
+++ b/web/src/routes/managers/+page.svelte
@@ -62,8 +62,8 @@
 			<div class="text-2xl text-slate-400">Loading manager profiles...</div>
 		</div>
 	{:else if currentManager}
-		<!-- Left Sidebar - Manager Selector -->
-		<div class="w-20 bg-slate-800/50 border-r border-slate-700/50 flex flex-col items-center py-6 space-y-3 overflow-y-auto">
+		<!-- Left Sidebar - Manager Selector (desktop) -->
+		<div class="hidden sm:flex w-20 bg-slate-800/50 border-r border-slate-700/50 flex-col items-center py-6 space-y-3 overflow-y-auto">
 			{#each managers as manager}
 				<button
 					on:click={() => selectManager(manager.managerName)}
@@ -88,11 +88,25 @@
 		</div>
 
 		<!-- Main Content Area -->
-		<div class="flex-1 flex flex-col">
+		<div class="flex-1 flex flex-col min-w-0">
+			<!-- Mobile Manager Selector -->
+			<div class="sm:hidden p-4 border-b border-slate-700/50">
+				<label for="mobile-manager-select" class="sr-only">Select manager</label>
+				<select
+					id="mobile-manager-select"
+					bind:value={selectedManagerName}
+					class="w-full bg-slate-700 text-white px-4 py-3 rounded-lg border border-slate-600 focus:border-blue-400 focus:outline-none text-base font-medium"
+				>
+					{#each managers as manager}
+						<option value={manager.managerName}>{manager.managerName}</option>
+					{/each}
+				</select>
+			</div>
+
 			<!-- Header -->
-			<div class="bg-slate-800/30 border-b border-slate-700/50 px-8 py-6">
-				<div class="flex items-center justify-between">
-					<div class="flex items-center gap-6">
+			<div class="bg-slate-800/30 border-b border-slate-700/50 px-4 sm:px-8 py-6">
+				<div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+					<div class="flex items-center gap-4 sm:gap-6 min-w-0">
 						<!-- Large Profile Picture -->
 						{#if currentManager.managerName}
 						<ManagerProfilePicture 
@@ -103,8 +117,8 @@
 						{/if}
 						
 						<!-- Manager Info -->
-						<div>
-							<h1 class="text-4xl font-bold text-white mb-2">
+						<div class="min-w-0">
+							<h1 class="text-3xl sm:text-4xl font-bold text-white mb-2 break-words">
 								{currentManager.managerName}
 								{#if currentManager.totalChampionships > 0}
 									<span class="ml-3">{getChampionshipBadge(currentManager.totalChampionships)}</span>
@@ -122,12 +136,12 @@
 					</div>
 					
 					<!-- Quick Stats -->
-					<div class="text-right">
-						<div class="flex items-baseline justify-end gap-6 mb-1">
-							<div class="text-3xl font-bold text-slate-300">
+					<div class="sm:text-right shrink-0">
+						<div class="flex items-baseline gap-6 mb-1 sm:justify-end">
+							<div class="text-2xl sm:text-3xl font-bold text-slate-300">
 								<span class="text-green-400">{currentManager.totalWins || 0}</span>-<span class="text-red-400">{currentManager.totalLosses || 0}</span>-<span class="text-amber-400">{currentManager.totalTies || 0}</span>
 							</div>
-							<div class="text-3xl font-bold {getWinPercentageColor(parseFloat(currentManager.winPercentage || 0))}">
+							<div class="text-2xl sm:text-3xl font-bold {getWinPercentageColor(parseFloat(currentManager.winPercentage || 0))}">
 								{parseFloat(currentManager.winPercentage || 0).toFixed(3)}
 							</div>
 						</div>
@@ -141,7 +155,7 @@
 			</div>
 
 			<!-- Main Stats Grid -->
-			<div class="flex-1 p-8 overflow-y-auto">
+			<div class="flex-1 p-4 sm:p-8 overflow-y-auto">
 				<div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
 					
 					<!-- Left Column: Core Stats -->
@@ -153,7 +167,7 @@
 								<BarChart3 class="w-5 h-5 text-blue-400 mr-2" />
 								League Tenure & Impact
 							</h3>
-							<div class="grid grid-cols-4 gap-6">
+							<div class="grid grid-cols-2 sm:grid-cols-4 gap-4 sm:gap-6">
 								<div class="text-center">
 									<div class="text-3xl font-bold text-purple-400">{currentManager.totalSeasons}</div>
 									<div class="text-slate-400 font-medium">Seasons</div>
@@ -179,7 +193,7 @@
 								<Target class="w-5 h-5 text-green-400 mr-2" />
 								Scoring Performance
 							</h3>
-							<div class="grid grid-cols-3 gap-6">
+							<div class="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
 								<div class="text-center">
 									<div class="text-2xl font-bold text-blue-400">{parseFloat(currentManager.avgPointsFor || 0).toFixed(1)}</div>
 									<div class="text-slate-400 text-sm">Avg Points/Season</div>
@@ -205,7 +219,7 @@
 								<Crown class="w-5 h-5 text-amber-400 mr-2" />
 								League Rankings
 							</h3>
-							<div class="grid grid-cols-4 gap-4">
+							<div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
 								<div class="text-center p-4 bg-slate-900/30 rounded-lg">
 									<div class="text-xl font-bold text-amber-400">#{currentManager.championshipRank}</div>
 									<div class="text-slate-400 text-sm">Championships</div>


### PR DESCRIPTION
Mobile formatting:
- Managers page: the desktop sidebar selector and fixed grid-cols-3/4 caused horizontal overflow and no usable way to switch managers on a phone. Hide the sidebar on mobile and add a full-width dropdown selector; make the header stack and the stat grids responsive (grid-cols-2 sm:grid-cols-4, etc.).
- Hall of Fame: the ranking-card row was flex justify-between that never wrapped, squeezing the right-hand stats grid into overlapping text on mobile. Stack the name block above the stats on small screens (flex-col lg:flex-row).

Draft grades:
- DraftAnalysis graded on an absolute threshold (avg pts/pick >= 100 = A), but a full-season player naturally scores 100+, so everyone got an A every season. Grade on the season's own curve instead (z-score of avg points/pick across that season's managers). Verified 2005: Bobby A, Israel/Trevor C, Luke S F.

Verified on a 390px viewport: no horizontal overflow, dropdown lists all 11 managers, ranking-card stats render in a clean 2-col grid.