### PR TITLE
Fix the Resend wiring: batch the fan-out, surface misconfiguration, close the settle race

### DIFF
--- a/web/src/lib/server/constitution/evaluate.ts
+++ b/web/src/lib/server/constitution/evaluate.ts
@@ -106,25 +106,52 @@ export async function settleProposal(
 		return outcome;
 	}
 
+	// Everything below settles the proposal, so the transition must be claimed
+	// atomically.
+	//
+	// The SELECT above takes no row lock, and settleDueProposals() runs from a
+	// *page load* — so two managers opening /constitution in the same second
+	// past a deadline both read status 'active', both settle, and both fan out
+	// to the whole league. The `status = 'active'` predicate is the claim: under
+	// READ COMMITTED the loser blocks on the row, re-evaluates the predicate
+	// once the winner commits, matches zero rows, and returns null so its caller
+	// skips the notification. Same atomic-claim shape as consumeLoginToken().
+	const stillActive = and(
+		eq(ruleProposal.proposalKey, proposalKey),
+		eq(ruleProposal.status, 'active')
+	);
+
 	if (outcome.state === 'rejected') {
-		await tx
+		const [claimedRejection] = await tx
 			.update(ruleProposal)
 			.set({ ...counters, status: 'rejected', settledAt: now })
-			.where(eq(ruleProposal.proposalKey, proposalKey));
-		return outcome;
+			.where(stillActive)
+			.returning({ proposalKey: ruleProposal.proposalKey });
+
+		return claimedRejection ? outcome : null;
 	}
 
-	// Passed. Import lazily to keep a cycle from forming: apply.ts needs the
-	// tally shape from here, and this needs the applier.
+	// Passed. Claimed BEFORE the amendment is applied, so the text change is
+	// written by the one transaction that owns the transition, not by every racer.
+	const [claimedPassage] = await tx
+		.update(ruleProposal)
+		.set({ ...counters, status: 'passed', settledAt: now })
+		.where(stillActive)
+		.returning({ proposalKey: ruleProposal.proposalKey });
+
+	if (!claimedPassage) return null;
+
+	// Import lazily to keep a cycle from forming: apply.ts needs the tally shape
+	// from here, and this needs the applier.
 	const { applyPassedProposal } = await import('./apply');
 	const applied = await applyPassedProposal(tx, proposalKey, tally, now);
 
+	// Unconditional: the claim above already established that this transaction
+	// owns the row, and status is no longer 'active' for the guard to match.
 	await tx
 		.update(ruleProposal)
 		.set({
-			...counters,
 			status: applied.status,
-			settledAt: now,
 			appliedAt: applied.status === 'passed' ? now : null,
 			amendmentKey: applied.amendmentKey
 		})
@@ -161,7 +188,9 @@ export async function settleDueProposals(now: Date = new Date()): Promise<number
 		let outcome: Outcome | null = null;
 		try {
 			outcome = await db.transaction(async (tx) => settleProposal(tx, proposalKey, now));
-			settled += 1;
+			// A null outcome means another request claimed the transition first —
+			// it settled the proposal, not this sweep, and it owns the notification.
+			if (outcome) settled += 1;
 		} catch (error) {
 			console.error(`[constitution] Failed to settle proposal ${proposalKey}:`, error);
 			continue;

--- a/web/src/lib/server/email.test.ts
+++ b/web/src/lib/server/email.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The repo's .env is baked into $env/dynamic/private by the SvelteKit plugin
+// before vitest runs, so without this the transports would be built from
+// whatever key happens to be on the developer's laptop.
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		EMAIL_PROVIDER: 'console',
+		EMAIL_FROM: 'league@example.com',
+		EMAIL_FROM_NAME: 'The League',
+		NODE_ENV: 'test'
+	}
+}));
+
+const { ResendEmailService, formatFromHeader, generateMagicLinkEmail, MAX_BATCH } = await import(
+	'./email'
+);
+
+const FROM = () => ({ address: 'league@example.com', name: 'The League' });
+
+interface StubResponse {
+	status: number;
+	body?: unknown;
+	headers?: Record<string, string>;
+}
+
+interface RecordedCall {
+	url: string;
+	body: unknown;
+	headers: Record<string, string>;
+}
+
+/** A fetch that answers from a script, and records what it was asked. */
+function stubFetch(script: StubResponse[]) {
+	const calls: RecordedCall[] = [];
+	const order: string[] = [];
+	let next = 0;
+
+	const fetchImpl = (async (url: unknown, init: RequestInit) => {
+		const index = next++;
+		const spec = script[index] ?? { status: 500 };
+		const headers = init.headers as Record<string, string>;
+		calls.push({ url: String(url), body: JSON.parse(init.body as string), headers });
+
+		order.push(`start:${index}`);
+		// Yield, so a caller that fired requests concurrently would interleave.
+		await Promise.resolve();
+		order.push(`end:${index}`);
+
+		return new Response(spec.body === undefined ? null : JSON.stringify(spec.body), {
+			status: spec.status,
+			headers: spec.headers
+		});
+	}) as unknown as typeof fetch;
+
+	return { fetchImpl, calls, order };
+}
+
+function transport(script: StubResponse[], resolveFrom = FROM) {
+	const { fetchImpl, calls, order } = stubFetch(script);
+	const slept: number[] = [];
+	const logs: string[] = [];
+	const service = new ResendEmailService('test-key', resolveFrom, {
+		fetchImpl,
+		sleep: async (ms: number) => {
+			slept.push(ms);
+		},
+		newIdempotencyKey: () => 'fixed-key',
+		timeoutMs: 100,
+		log: (message: string) => logs.push(message)
+	});
+	return { service, calls, order, slept, logs };
+}
+
+const MESSAGE = { to: 'a@b.c', subject: 'Subject', html: '<p>Body</p>', text: 'Body' };
+
+describe('formatFromHeader', () => {
+	it('omits the display name when there is none', () => {
+		expect(formatFromHeader({ address: 'x@y.z', name: null })).toBe('x@y.z');
+	});
+
+	it('quotes a display name containing a comma', () => {
+		// Unquoted, "Smith, John <x@y.z>" parses as two addresses and the provider
+		// rejects the entire send rather than just the name.
+		expect(formatFromHeader({ address: 'x@y.z', name: 'Smith, John' })).toBe(
+			'"Smith, John" <x@y.z>'
+		);
+	});
+});
+
+describe('ResendEmailService.sendEmail', () => {
+	it('sends the from header and a single recipient', async () => {
+		const { service, calls } = transport([{ status: 200, body: { id: 'abc' } }]);
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(true);
+
+		expect(calls[0].body).toMatchObject({
+			from: 'The League <league@example.com>',
+			to: ['a@b.c'],
+			subject: 'Subject'
+		});
+	});
+
+	it('returns false without throwing when the from address cannot be resolved', async () => {
+		// Defect 2, and the contract that protects the login flow. If this threw,
+		// a provisioned address would get an error page while an unknown address
+		// still redirected quietly — which is the roster-enumeration oracle that
+		// login/+page.server.ts is built to avoid.
+		const { service, calls, logs } = transport([], () => {
+			throw new Error('EMAIL_FROM must be set when EMAIL_PROVIDER=resend.');
+		});
+
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(calls).toHaveLength(0);
+		expect(logs.join()).toContain('EMAIL_FROM');
+	});
+
+	it("surfaces Resend's top-level error message", async () => {
+		// The shape Resend actually returns. The previous code read only
+		// body.error.message, which never matches, so the single most common
+		// misconfiguration was reported as a bare "HTTP 403" and the sentence
+		// naming the fix was discarded.
+		const { service, logs } = transport([
+			{
+				status: 403,
+				body: {
+					statusCode: 403,
+					name: 'validation_error',
+					message: 'The example.com domain is not verified'
+				}
+			}
+		]);
+
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(logs.join()).toContain('domain is not verified');
+	});
+
+	it('still reads a nested error shape', async () => {
+		const { service, logs } = transport([{ status: 400, body: { error: { message: 'legacy' } } }]);
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(logs.join()).toContain('legacy');
+	});
+
+	it('falls back to the status when the body explains nothing', async () => {
+		const { service, logs } = transport([{ status: 500 }, { status: 500 }]);
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(logs.join()).toContain('HTTP 500');
+	});
+
+	it('retries once on 429 and succeeds', async () => {
+		const { service, calls, slept } = transport([
+			{ status: 429 },
+			{ status: 200, body: { id: 'abc' } }
+		]);
+
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(true);
+		expect(calls).toHaveLength(2);
+		expect(slept).toEqual([250]);
+	});
+
+	it('retries at most once', async () => {
+		// The failure the whole change exists to prevent: an unbounded retry loop
+		// hammering a provider that has already said stop.
+		const { service, calls } = transport([{ status: 429 }, { status: 429 }]);
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(calls).toHaveLength(2);
+	});
+
+	it('honours a short retry-after', async () => {
+		const { service, slept } = transport([
+			{ status: 429, headers: { 'retry-after': '1' } },
+			{ status: 200, body: { id: 'abc' } }
+		]);
+		await service.sendEmail(MESSAGE);
+		expect(slept).toEqual([1000]);
+	});
+
+	it('refuses to retry when told to wait longer than the budget', async () => {
+		// Waiting 60s inside a form action is worse than one logged failure, and
+		// retrying early would only earn a second refusal.
+		const { service, calls, slept } = transport([{ status: 429, headers: { 'retry-after': '60' } }]);
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(calls).toHaveLength(1);
+		expect(slept).toEqual([]);
+	});
+
+	it('tolerates an HTTP-date retry-after', async () => {
+		// Retry-After may be a date, which Number() turns into NaN.
+		// setTimeout(NaN) fires immediately, turning a paced retry into an instant
+		// re-flood, so the default delay has to win.
+		const { service, slept } = transport([
+			{ status: 503, headers: { 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' } },
+			{ status: 200, body: { id: 'abc' } }
+		]);
+		await service.sendEmail(MESSAGE);
+		expect(slept).toEqual([250]);
+	});
+
+	it('does not retry a 422', async () => {
+		// Permanent. Re-sending burns quota and risks a duplicate.
+		const { service, calls } = transport([{ status: 422, body: { message: 'bad address' } }]);
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(calls).toHaveLength(1);
+	});
+
+	it('reuses one idempotency key across the retry', async () => {
+		// What makes retrying an ambiguous 5xx safe: if the first attempt actually
+		// delivered, Resend dedupes the second rather than sending two sign-in
+		// links for one request.
+		const { service, calls } = transport([{ status: 500 }, { status: 200, body: { id: 'abc' } }]);
+		await service.sendEmail(MESSAGE);
+
+		expect(calls[0].headers['Idempotency-Key']).toBe(calls[1].headers['Idempotency-Key']);
+		expect(calls[0].headers['Idempotency-Key']).toBeTruthy();
+	});
+
+	it('does not retry a timeout', async () => {
+		// Two 8s attempts stacked inside a login action is worse than one failure,
+		// and a timeout means the request may have been received anyway.
+		const fetchImpl = (async () => {
+			throw new DOMException('The operation timed out.', 'TimeoutError');
+		}) as unknown as typeof fetch;
+
+		let attempts = 0;
+		const counting = (async (...args: Parameters<typeof fetch>) => {
+			attempts++;
+			return fetchImpl(...args);
+		}) as unknown as typeof fetch;
+
+		const service = new ResendEmailService('k', FROM, { fetchImpl: counting, log: () => {} });
+		await expect(service.sendEmail(MESSAGE)).resolves.toBe(false);
+		expect(attempts).toBe(1);
+	});
+});
+
+describe('ResendEmailService.sendBatch', () => {
+	const nine = Array.from({ length: 9 }, (_, i) => ({ ...MESSAGE, to: `m${i}@b.c` }));
+
+	it('sends nine recipients in one request', async () => {
+		const { service, calls } = transport([
+			{ status: 200, body: { data: nine.map((_, i) => ({ id: `id-${i}` })) } }
+		]);
+
+		const result = await service.sendBatch(nine);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].url).toBe('https://api.resend.com/emails/batch');
+		expect(calls[0].body).toHaveLength(9);
+		expect(result.succeeded).toBe(9);
+		expect(result.failed).toBe(0);
+	});
+
+	it('reports partial failure positionally', async () => {
+		const three = nine.slice(0, 3);
+		const { service } = transport([
+			{ status: 200, body: { data: [{ id: 'a' }, null, { id: 'c' }] } }
+		]);
+
+		const result = await service.sendBatch(three);
+		expect(result.sent).toEqual([true, false, true]);
+		expect(result.succeeded).toBe(2);
+		expect(result.failed).toBe(1);
+	});
+
+	it('fails the whole chunk when the response does not cover every message', async () => {
+		// The load-bearing case. A short array means an entry was omitted and we
+		// cannot tell which — attributing ids by position would shift every index,
+		// naming the wrong managers AND marking a failed address as sent.
+		const three = nine.slice(0, 3);
+		const { service, logs } = transport([{ status: 200, body: { data: [{ id: 'a' }] } }]);
+
+		const result = await service.sendBatch(three);
+		expect(result.sent).toEqual([false, false, false]);
+		expect(logs.join()).toContain('covered 1 of 3');
+	});
+
+	it('fails everything when the response has no data key', async () => {
+		const { service } = transport([{ status: 200, body: {} }]);
+		const result = await service.sendBatch(nine.slice(0, 2));
+		expect(result.succeeded).toBe(0);
+	});
+
+	it('makes no request for an empty list', async () => {
+		const { service, calls } = transport([]);
+		const result = await service.sendBatch([]);
+		expect(calls).toHaveLength(0);
+		expect(result).toEqual({ sent: [], succeeded: 0, failed: 0 });
+	});
+
+	it('resolves rather than rejecting when fetch throws', async () => {
+		const fetchImpl = (async () => {
+			throw new Error('network down');
+		}) as unknown as typeof fetch;
+		const service = new ResendEmailService('k', FROM, { fetchImpl, log: () => {} });
+
+		const result = await service.sendBatch(nine);
+		expect(result.sent).toHaveLength(9);
+		expect(result.succeeded).toBe(0);
+	});
+
+	it('chunks above the batch ceiling and sends the chunks sequentially', async () => {
+		// Guards two failures at once: silently dropping message 101, and
+		// reintroducing the concurrency this change exists to remove.
+		const many = Array.from({ length: MAX_BATCH + 5 }, (_, i) => ({ ...MESSAGE, to: `m${i}@b.c` }));
+		const { service, calls, order } = transport([
+			{ status: 200, body: { data: Array.from({ length: MAX_BATCH }, (_, i) => ({ id: `a${i}` })) } },
+			{ status: 200, body: { data: Array.from({ length: 5 }, (_, i) => ({ id: `b${i}` })) } }
+		]);
+
+		const result = await service.sendBatch(many);
+		expect(calls).toHaveLength(2);
+		expect(calls[0].body).toHaveLength(MAX_BATCH);
+		expect(calls[1].body).toHaveLength(5);
+		expect(order).toEqual(['start:0', 'end:0', 'start:1', 'end:1']);
+		expect(result.succeeded).toBe(MAX_BATCH + 5);
+	});
+
+	it('marks only the failing chunk', async () => {
+		const many = Array.from({ length: MAX_BATCH + 5 }, (_, i) => ({ ...MESSAGE, to: `m${i}@b.c` }));
+		const { service } = transport([
+			{ status: 200, body: { data: Array.from({ length: MAX_BATCH }, (_, i) => ({ id: `a${i}` })) } },
+			{ status: 429 },
+			{ status: 429 }
+		]);
+
+		const result = await service.sendBatch(many);
+		expect(result.succeeded).toBe(MAX_BATCH);
+		expect(result.failed).toBe(5);
+	});
+});
+
+describe('generateMagicLinkEmail', () => {
+	const url = 'https://league.example/login/verify?token=abc';
+
+	it('escapes a display name in the HTML body', async () => {
+		const mail = generateMagicLinkEmail(url, 'a@b.c', {
+			purpose: 'invite',
+			displayName: '<script>alert(1)</script>'
+		});
+
+		expect(mail.html).not.toContain('<script');
+		expect(mail.html).toContain('&lt;script');
+	});
+
+	it('leaves the display name raw in the text body', async () => {
+		// The regression the escaping fix invites. Sharing one greeting between
+		// both bodies fixes the injection and makes O'Brien read "O&#39;Brien" in
+		// plain text in the same edit.
+		const mail = generateMagicLinkEmail(url, 'a@b.c', {
+			purpose: 'login',
+			displayName: "O'Brien"
+		});
+
+		expect(mail.text).toContain("Hi O'Brien,");
+		expect(mail.html).toContain('O&#39;Brien');
+	});
+
+	it('falls back cleanly with no display name', async () => {
+		const mail = generateMagicLinkEmail(url, 'a@b.c', { purpose: 'login', displayName: null });
+		expect(mail.text).toContain('Hi,');
+		expect(mail.html).toContain('Hi,');
+		expect(mail.text).not.toContain('undefined');
+		expect(mail.html).not.toContain('undefined');
+	});
+
+	it('keeps the pasteable link intact in the text body', async () => {
+		// The fallback for when the button does not render. An entity-encoded URL
+		// here would be pasted broken.
+		const multi = 'https://league.example/login/verify?token=abc&redirect=%2Fhome';
+		const mail = generateMagicLinkEmail(multi, 'a@b.c', { purpose: 'login' });
+
+		expect(mail.text).toContain(multi);
+		// Correct inside an href: attribute values are entity-decoded before the
+		// URL is resolved, so this still points at the same place.
+		expect(mail.html).toContain('token=abc&amp;redirect=%2Fhome');
+	});
+
+	it('distinguishes an invite from a sign-in', async () => {
+		const invite = generateMagicLinkEmail(url, 'a@b.c', { purpose: 'invite' });
+		const login = generateMagicLinkEmail(url, 'a@b.c', { purpose: 'login' });
+		expect(invite.subject).not.toBe(login.subject);
+	});
+});

--- a/web/src/lib/server/email.ts
+++ b/web/src/lib/server/email.ts
@@ -2,9 +2,10 @@ import {
 	EMAIL_PROVIDER,
 	RESEND_API_KEY,
 	SENDGRID_API_KEY,
-	EMAIL_FROM,
-	EMAIL_FROM_NAME
+	EMAIL_FROM_NAME,
+	requireEmailFrom
 } from './env';
+import { escapeHtml } from './html';
 
 export interface EmailOptions {
 	to: string;
@@ -13,12 +14,130 @@ export interface EmailOptions {
 	text?: string;
 }
 
+/** Split rather than pre-formatted: SendGrid wants {email, name}, Resend wants one header string. */
+export interface FromAddress {
+	address: string;
+	name: string | null;
+}
+
+/**
+ * Resolved per send and ALLOWED TO THROW — transports must call it inside their
+ * own try/catch. See the EmailService contract below.
+ */
+export type ResolveFrom = () => FromAddress;
+
+/** Positional: `sent[i]` describes `messages[i]`, so a caller can name who missed. */
+export interface BatchResult {
+	sent: boolean[];
+	succeeded: number;
+	failed: number;
+}
+
 export interface EmailService {
 	/** Resolves false on failure. Implementations must never throw — see below. */
 	sendEmail(options: EmailOptions): Promise<boolean>;
+	/** Resolves a per-message verdict. Must never throw and never reject. */
+	sendBatch(messages: EmailOptions[]): Promise<BatchResult>;
 }
 
-class ConsoleEmailService implements EmailService {
+/** Everything a transport talks to that a test needs to replace. */
+export interface TransportOptions {
+	fetchImpl?: typeof fetch;
+	sleep?: (ms: number) => Promise<void>;
+	newIdempotencyKey?: () => string;
+	timeoutMs?: number;
+	log?: (message: string) => void;
+}
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const RESEND_BATCH_ENDPOINT = 'https://api.resend.com/emails/batch';
+
+/** Resend accepts at most 100 messages per batch request. */
+export const MAX_BATCH = 100;
+/** Longer than this and we skip the retry rather than stall a form action. */
+export const MAX_RETRY_WAIT_MS = 1000;
+export const DEFAULT_RETRY_WAIT_MS = 250;
+export const DEFAULT_TIMEOUT_MS = 8000;
+
+// ---------------------------------------------------------------------------
+// Shared transport helpers
+// ---------------------------------------------------------------------------
+
+export function formatFromHeader(from: FromAddress): string {
+	if (!from.name) return from.address;
+	// A display name containing a comma parses as two addresses unless it is
+	// quoted, and the provider rejects the whole send rather than the name.
+	const name = /["(),:;<>@[\\\]]/.test(from.name)
+		? `"${from.name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+		: from.name;
+	return `${name} <${from.address}>`;
+}
+
+function isRetryable(status: number): boolean {
+	return status === 429 || status >= 500;
+}
+
+/** Milliseconds to wait before the single retry, or null meaning "do not retry". */
+function retryDelayMs(response: Response): number | null {
+	const header = response.headers.get('retry-after');
+	if (header === null) return DEFAULT_RETRY_WAIT_MS;
+
+	const seconds = Number(header);
+	// Retry-After is also allowed to be an HTTP-date, which Number() turns into
+	// NaN. setTimeout(NaN) fires immediately, so treating it as a delay would
+	// turn a paced retry into an instant re-flood of a provider that just asked
+	// us to slow down. Fall back to our own schedule instead.
+	if (!Number.isFinite(seconds) || seconds < 0) return DEFAULT_RETRY_WAIT_MS;
+
+	const ms = seconds * 1000;
+	// Told to wait longer than our budget: skip the retry rather than sleep into
+	// a certain second refusal. This runs inside a form action, and a manager
+	// watching a spinner is a worse outcome than one logged failure.
+	return ms > MAX_RETRY_WAIT_MS ? null : ms;
+}
+
+function describeFailure(status: number, body: unknown): string {
+	// Resend reports errors as {statusCode, name, message} at the TOP level. The
+	// previous code read only body.error.message, which never matches, so the
+	// most common misconfiguration of all — an unverified sending domain —
+	// surfaced as a bare "HTTP 403" with the sentence naming the fix discarded.
+	// Both shapes are read because swapping one guess for another is not a fix.
+	const record = (body ?? {}) as Record<string, unknown>;
+	const nested = record.error;
+	if (typeof nested === 'string' && nested) return nested;
+	if (nested && typeof nested === 'object') {
+		const message = (nested as Record<string, unknown>).message;
+		if (typeof message === 'string' && message) return message;
+	}
+	if (typeof record.message === 'string' && record.message) return record.message;
+	return `HTTP ${status}`;
+}
+
+function tally(sent: boolean[]): BatchResult {
+	const succeeded = sent.filter(Boolean).length;
+	return { sent, succeeded, failed: sent.length - succeeded };
+}
+
+/**
+ * Default fan-out: one message at a time.
+ *
+ * Sequential rather than Promise.all deliberately. Unbounded concurrency is the
+ * bug this batching work exists to remove, and a transport that inherits this
+ * should inherit the pacing too. Resend overrides it with a real batch call.
+ */
+abstract class BaseEmailService implements EmailService {
+	abstract sendEmail(options: EmailOptions): Promise<boolean>;
+
+	async sendBatch(messages: EmailOptions[]): Promise<BatchResult> {
+		const sent: boolean[] = [];
+		for (const message of messages) {
+			sent.push(await this.sendEmail(message));
+		}
+		return tally(sent);
+	}
+}
+
+class ConsoleEmailService extends BaseEmailService {
 	async sendEmail(options: EmailOptions): Promise<boolean> {
 		console.log('\n📧 EMAIL (Console Mode)');
 		console.log('=======================');
@@ -30,51 +149,190 @@ class ConsoleEmailService implements EmailService {
 	}
 }
 
-class ResendEmailService implements EmailService {
-	constructor(private apiKey: string) {}
+class ResendEmailService extends BaseEmailService {
+	private readonly fetchImpl: typeof fetch;
+	private readonly sleep: (ms: number) => Promise<void>;
+	private readonly newIdempotencyKey: () => string;
+	private readonly timeoutMs: number;
+	private readonly log: (message: string) => void;
 
-	async sendEmail(options: EmailOptions): Promise<boolean> {
-		try {
-			const response = await fetch('https://api.resend.com/emails', {
+	constructor(
+		private apiKey: string,
+		private resolveFrom: ResolveFrom,
+		opts: TransportOptions = {}
+	) {
+		super();
+		this.fetchImpl = opts.fetchImpl ?? ((...args) => globalThis.fetch(...args));
+		this.sleep = opts.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+		this.newIdempotencyKey = opts.newIdempotencyKey ?? (() => crypto.randomUUID());
+		this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		this.log = opts.log ?? ((message) => console.error(message));
+	}
+
+	/**
+	 * One POST, with at most one retry.
+	 *
+	 * Both attempts carry the SAME Idempotency-Key. That is what makes retrying
+	 * an ambiguous 5xx safe: if the first attempt actually delivered, Resend
+	 * dedupes the second within its 24h window rather than mailing twice.
+	 *
+	 * A timeout is deliberately NOT retried — it rejects out of this loop. Two
+	 * 8s attempts stacked inside a login form action is worse than one failure,
+	 * and a timeout means the request may well have been received anyway.
+	 */
+	private async post(
+		url: string,
+		payload: unknown
+	): Promise<{ ok: boolean; status: number; body: unknown }> {
+		const idempotencyKey = this.newIdempotencyKey();
+
+		for (let attempt = 0; ; attempt++) {
+			const response = await this.fetchImpl(url, {
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${this.apiKey}`,
-					'Content-Type': 'application/json'
+					'Content-Type': 'application/json',
+					'Idempotency-Key': idempotencyKey
 				},
-				body: JSON.stringify({
-					from: EMAIL_FROM_NAME ? `${EMAIL_FROM_NAME} <${EMAIL_FROM}>` : EMAIL_FROM,
-					to: [options.to],
-					subject: options.subject,
-					html: options.html,
-					...(options.text ? { text: options.text } : {})
-				})
+				body: JSON.stringify(payload),
+				signal: AbortSignal.timeout(this.timeoutMs)
 			});
 
-			// Resend reports some failures in the body rather than by status, so a
-			// 200 alone is not proof of a send. An unverified sending domain shows
-			// up exactly here.
 			const body = await response.json().catch(() => null);
+			if (response.ok) return { ok: true, status: response.status, body };
 
-			if (!response.ok || body?.error) {
-				const detail = body?.error?.message ?? body?.message ?? `HTTP ${response.status}`;
-				console.error(`[email] Resend refused the message to ${options.to}: ${detail}`);
+			// 422 and friends are permanent — an unverified domain or a malformed
+			// address does not become valid on a second try, and re-sending burns
+			// quota and risks a duplicate.
+			if (attempt === 0 && isRetryable(response.status)) {
+				const wait = retryDelayMs(response);
+				if (wait !== null) {
+					await this.sleep(wait);
+					continue;
+				}
+			}
+
+			return { ok: false, status: response.status, body };
+		}
+	}
+
+	async sendEmail(options: EmailOptions): Promise<boolean> {
+		try {
+			// Inside the try, deliberately. The EmailService contract promises never
+			// to throw and the login form action depends on it: an exception here
+			// would make a provisioned address error while an unknown address still
+			// redirects quietly, reopening the enumeration oracle that
+			// login/+page.server.ts exists to close.
+			const from = formatFromHeader(this.resolveFrom());
+
+			const { ok, status, body } = await this.post(RESEND_ENDPOINT, {
+				from,
+				to: [options.to],
+				subject: options.subject,
+				html: options.html,
+				...(options.text ? { text: options.text } : {})
+			});
+
+			if (!ok) {
+				this.log(`[email] Resend refused the message to ${options.to}: ${describeFailure(status, body)}`);
 				return false;
 			}
 
 			return true;
 		} catch (error) {
-			console.error('[email] Resend request failed:', error);
+			this.log(`[email] Resend request for ${options.to} failed: ${error}`);
 			return false;
 		}
 	}
+
+	async sendBatch(messages: EmailOptions[]): Promise<BatchResult> {
+		if (messages.length === 0) return tally([]);
+
+		const sent: boolean[] = [];
+		try {
+			const from = formatFromHeader(this.resolveFrom());
+
+			// Chunks go out one after another. Sending them concurrently would
+			// recreate exactly the burst this method replaces.
+			for (let i = 0; i < messages.length; i += MAX_BATCH) {
+				const chunk = messages.slice(i, i + MAX_BATCH);
+				sent.push(...(await this.postChunk(from, chunk)));
+			}
+		} catch (error) {
+			this.log(`[email] Resend batch failed: ${error}`);
+		}
+
+		// Anything we never got a verdict for — a throw partway through, or a
+		// resolveFrom() that failed before the first request — counts as failed.
+		while (sent.length < messages.length) sent.push(false);
+		return tally(sent);
+	}
+
+	private async postChunk(from: string, chunk: EmailOptions[]): Promise<boolean[]> {
+		const { ok, status, body } = await this.post(
+			RESEND_BATCH_ENDPOINT,
+			chunk.map((message) => ({
+				from,
+				to: [message.to],
+				subject: message.subject,
+				html: message.html,
+				...(message.text ? { text: message.text } : {})
+			}))
+		);
+
+		if (!ok) {
+			this.log(
+				`[email] Resend refused a batch of ${chunk.length}: ${describeFailure(status, body)}`
+			);
+			return chunk.map(() => false);
+		}
+
+		const data = (body as { data?: unknown } | null)?.data;
+		const entries = Array.isArray(data) ? data : [];
+
+		// Positions are only trustworthy when Resend vouches for every message.
+		// Same-index correspondence is documented for the all-success shape only;
+		// the partially-failed shape is not documented at all. A short array means
+		// an entry was omitted and we cannot tell which, so attributing ids by
+		// position would name the wrong managers AND mark a failed address sent.
+		// Fail the chunk and log the body verbatim — a spurious "failed" beats a
+		// confident lie.
+		if (entries.length !== chunk.length) {
+			this.log(
+				`[email] Resend batch response covered ${entries.length} of ${chunk.length} messages; ` +
+					`not attributing ids by position. Body: ${JSON.stringify(body)}`
+			);
+			return chunk.map(() => false);
+		}
+
+		return chunk.map((_, i) => {
+			const id = (entries[i] as { id?: unknown } | null)?.id;
+			return typeof id === 'string' && id.length > 0;
+		});
+	}
 }
 
-class SendGridEmailService implements EmailService {
-	constructor(private apiKey: string) {}
+class SendGridEmailService extends BaseEmailService {
+	private readonly fetchImpl: typeof fetch;
+	private readonly timeoutMs: number;
+	private readonly log: (message: string) => void;
+
+	constructor(
+		private apiKey: string,
+		private resolveFrom: ResolveFrom,
+		opts: TransportOptions = {}
+	) {
+		super();
+		this.fetchImpl = opts.fetchImpl ?? ((...args) => globalThis.fetch(...args));
+		this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		this.log = opts.log ?? ((message) => console.error(message));
+	}
 
 	async sendEmail(options: EmailOptions): Promise<boolean> {
 		try {
-			const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+			const from = this.resolveFrom();
+
+			const response = await this.fetchImpl('https://api.sendgrid.com/v3/mail/send', {
 				method: 'POST',
 				headers: {
 					Authorization: `Bearer ${this.apiKey}`,
@@ -82,25 +340,39 @@ class SendGridEmailService implements EmailService {
 				},
 				body: JSON.stringify({
 					personalizations: [{ to: [{ email: options.to }], subject: options.subject }],
-					from: { email: EMAIL_FROM, name: EMAIL_FROM_NAME },
+					from: { email: from.address, ...(from.name ? { name: from.name } : {}) },
 					content: [
 						{ type: 'text/html', value: options.html },
 						...(options.text ? [{ type: 'text/plain', value: options.text }] : [])
 					]
-				})
+				}),
+				signal: AbortSignal.timeout(this.timeoutMs)
 			});
 
 			if (!response.ok) {
-				console.error('[email] SendGrid API error:', response.status, await response.text());
+				this.log(`[email] SendGrid API error: ${response.status} ${await response.text()}`);
 				return false;
 			}
 
 			return true;
 		} catch (error) {
-			console.error('[email] SendGrid request failed:', error);
+			this.log(`[email] SendGrid request for ${options.to} failed: ${error}`);
 			return false;
 		}
 	}
+}
+
+/**
+ * A thunk, not a value.
+ *
+ * createEmailService() runs at module load, which happens during `vite build`
+ * while SvelteKit analyses routes — so resolving EMAIL_FROM here would fail the
+ * build on a machine that has no reason to hold mail config. Transports call
+ * this inside their try/catch instead, where a missing value degrades to
+ * `return false` plus a named log.
+ */
+function resolveFrom(): FromAddress {
+	return { address: requireEmailFrom(), name: EMAIL_FROM_NAME || null };
 }
 
 function createEmailService(): EmailService {
@@ -110,14 +382,14 @@ function createEmailService(): EmailService {
 				console.warn('⚠️  Resend API key not found, falling back to console mode');
 				return new ConsoleEmailService();
 			}
-			return new ResendEmailService(RESEND_API_KEY);
+			return new ResendEmailService(RESEND_API_KEY, resolveFrom);
 
 		case 'sendgrid':
 			if (!SENDGRID_API_KEY) {
 				console.warn('⚠️  SendGrid API key not found, falling back to console mode');
 				return new ConsoleEmailService();
 			}
-			return new SendGridEmailService(SENDGRID_API_KEY);
+			return new SendGridEmailService(SENDGRID_API_KEY, resolveFrom);
 
 		case 'console':
 		default:
@@ -126,6 +398,9 @@ function createEmailService(): EmailService {
 }
 
 export const emailService = createEmailService();
+
+/** Exported for tests, which construct transports directly with stubbed dependencies. */
+export { ConsoleEmailService, ResendEmailService, SendGridEmailService };
 
 // ---------------------------------------------------------------------------
 // Templates
@@ -144,12 +419,21 @@ function layout(heading: string, bodyHtml: string): string {
 }
 
 function button(url: string, label: string): string {
+	// Escaped even though today's URL cannot break out: the token is
+	// encodeURIComponent'd and ORIGIN is operator-set, but that invariant lives
+	// two modules away and is one refactor from being false.
+	//
+	// Turning `&` into `&amp;` inside an href is CORRECT — attribute values are
+	// entity-decoded before the URL is resolved — so a future multi-parameter
+	// link still works. Nobody should "fix" this back.
+	const href = escapeHtml(url);
+
 	return `
 		<div style="text-align: center; margin: 28px 0;">
-			<a href="${url}" style="background-color: #f59e0b; color: #0f172a; padding: 12px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; display: inline-block;">${label}</a>
+			<a href="${href}" style="background-color: #f59e0b; color: #0f172a; padding: 12px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; display: inline-block;">${label}</a>
 		</div>
 		<p style="color: #94a3b8; font-size: 13px; margin-bottom: 8px;">If the button doesn't work, paste this into your browser:</p>
-		<p style="color: #cbd5e1; font-size: 13px; word-break: break-all; background-color: #0f172a; padding: 10px; border-radius: 6px; margin: 0;">${url}</p>
+		<p style="color: #cbd5e1; font-size: 13px; word-break: break-all; background-color: #0f172a; padding: 10px; border-radius: 6px; margin: 0;">${href}</p>
 	`;
 }
 
@@ -158,7 +442,12 @@ export function generateMagicLinkEmail(
 	to: string,
 	opts: { purpose: 'login' | 'invite'; displayName?: string | null }
 ): EmailOptions {
-	const greeting = opts.displayName ? `Hi ${opts.displayName},` : 'Hi,';
+	// Two greetings, not one. The HTML body must be escaped or a display name is
+	// an injection point; the text/plain body must NOT be, or a manager called
+	// O'Brien reads "Hi O&#39;Brien," in their mail client. Sharing one value
+	// here fixes the injection and introduces that bug in the same edit.
+	const greetingHtml = opts.displayName ? `Hi ${escapeHtml(opts.displayName)},` : 'Hi,';
+	const greetingText = opts.displayName ? `Hi ${opts.displayName},` : 'Hi,';
 	const isInvite = opts.purpose === 'invite';
 
 	const intro = isInvite
@@ -168,7 +457,7 @@ export function generateMagicLinkEmail(
 	const html = layout(
 		isInvite ? "You're in" : 'Sign in',
 		`
-			<p style="color: #e2e8f0; margin-bottom: 16px;">${greeting}</p>
+			<p style="color: #e2e8f0; margin-bottom: 16px;">${greetingHtml}</p>
 			<p style="color: #e2e8f0; margin-bottom: 8px;">${intro}</p>
 			${button(url, isInvite ? 'Sign in to The League' : 'Sign in')}
 			<p style="color: #94a3b8; font-size: 13px; margin-top: 24px;">
@@ -178,7 +467,9 @@ export function generateMagicLinkEmail(
 		`
 	);
 
-	const text = `${greeting}
+	// Raw url, deliberately. This is the copy-and-paste fallback; an entity-encoded
+	// link here would be pasted broken.
+	const text = `${greetingText}
 
 ${intro}
 

--- a/web/src/lib/server/env.test.ts
+++ b/web/src/lib/server/env.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * env.ts reads $env/dynamic/private at module load and caches the values in
+ * consts, so each configuration needs its own module instance.
+ */
+async function loadEnv(overrides: Record<string, string | undefined>) {
+	vi.resetModules();
+	vi.doMock('$env/dynamic/private', () => ({ env: overrides }));
+	return import('./env');
+}
+
+const CONFIGURED = {
+	NODE_ENV: 'production',
+	EMAIL_PROVIDER: 'resend',
+	RESEND_API_KEY: 'key',
+	EMAIL_FROM: 'league@example.com',
+	ORIGIN: 'https://league.example',
+	DATABASE_URL: 'postgres://x'
+};
+
+describe('describeMailConfig', () => {
+	it('reports nothing when everything is set', async () => {
+		const { describeMailConfig } = await loadEnv(CONFIGURED);
+		expect(describeMailConfig()).toEqual({ ok: true, problems: [] });
+	});
+
+	it('flags a provider selected without a from address', async () => {
+		// Defect 2. EMAIL_FROM_NAME defaults but EMAIL_FROM does not, so the
+		// header became "The League <undefined>" and every message was rejected
+		// with nothing but a per-attempt log line to show for it.
+		const { describeMailConfig } = await loadEnv({ ...CONFIGURED, EMAIL_FROM: undefined });
+		const { ok, problems } = describeMailConfig();
+
+		expect(ok).toBe(false);
+		expect(problems.join()).toContain('EMAIL_FROM');
+	});
+
+	it('flags a provider selected without its API key', async () => {
+		// Worse than no provider: the service quietly falls back to console mode,
+		// so sends land in a serverless log and everything reports success.
+		const { describeMailConfig } = await loadEnv({ ...CONFIGURED, RESEND_API_KEY: undefined });
+		expect(describeMailConfig().problems.join()).toContain('RESEND_API_KEY');
+	});
+
+	it('flags console mode in production', async () => {
+		const { describeMailConfig } = await loadEnv({ ...CONFIGURED, EMAIL_PROVIDER: 'console' });
+		expect(describeMailConfig().problems.join()).toContain('console');
+	});
+
+	it('stays quiet for console mode in development', async () => {
+		// Why the banner is invisible on a dev machine: console mode is the
+		// documented way to test sign-in locally, so it is not a problem there.
+		const { describeMailConfig } = await loadEnv({
+			NODE_ENV: 'development',
+			EMAIL_PROVIDER: 'console'
+		});
+		expect(describeMailConfig().ok).toBe(true);
+	});
+
+	it('does not demand EMAIL_FROM in console mode', async () => {
+		const { describeMailConfig } = await loadEnv({
+			NODE_ENV: 'development',
+			EMAIL_PROVIDER: 'console',
+			EMAIL_FROM: undefined
+		});
+		expect(describeMailConfig().ok).toBe(true);
+	});
+});
+
+describe('requireEmailFrom', () => {
+	it('throws when a provider is configured without an address', async () => {
+		const { requireEmailFrom } = await loadEnv({ ...CONFIGURED, EMAIL_FROM: undefined });
+		expect(() => requireEmailFrom()).toThrow(/EMAIL_FROM/);
+	});
+
+	it('throws in development too, unlike requireOrigin', async () => {
+		// Gated on the provider rather than on isProduction: EMAIL_FROM has no
+		// correct default in any environment, and the developer pointing a real
+		// key at a local run is exactly who needs the named failure.
+		const { requireEmailFrom } = await loadEnv({
+			NODE_ENV: 'development',
+			EMAIL_PROVIDER: 'resend',
+			RESEND_API_KEY: 'key'
+		});
+		expect(() => requireEmailFrom()).toThrow(/EMAIL_FROM/);
+	});
+
+	it('stays silent in console mode', async () => {
+		const { requireEmailFrom } = await loadEnv({
+			NODE_ENV: 'development',
+			EMAIL_PROVIDER: 'console'
+		});
+		expect(requireEmailFrom()).toBe('');
+	});
+});

--- a/web/src/lib/server/env.ts
+++ b/web/src/lib/server/env.ts
@@ -75,6 +75,78 @@ export function requireOrigin(): string {
 	return ORIGIN;
 }
 
+/**
+ * The address to send from, or an exception.
+ *
+ * Gated on the provider rather than on isProduction, unlike requireOrigin().
+ * ORIGIN has a *correct* default in development, so it only becomes wrong in
+ * production. EMAIL_FROM has no default at all — EMAIL_FROM_NAME defaults to
+ * 'The League' but the address does not — so an unset value built the header
+ * "The League <undefined>" and every provider rejected it. There is no
+ * environment in which that is right, and the person who most needs the loud
+ * failure is a developer pointing EMAIL_PROVIDER=resend at a real key locally.
+ *
+ * The console provider never reads `from`, so `npm run dev` and `vite build`
+ * are unaffected.
+ *
+ * NOTE: transports call this from inside their own try/catch, because the
+ * EmailService contract forbids throwing — so in practice this degrades to a
+ * `return false` with a named message rather than surfacing to a user. That is
+ * why describeMailConfig() exists: the log is not a surface anyone watches.
+ */
+export function requireEmailFrom(): string {
+	if (EMAIL_PROVIDER !== 'console' && !env.EMAIL_FROM) {
+		throw new Error(
+			`EMAIL_FROM must be set when EMAIL_PROVIDER=${EMAIL_PROVIDER}. ` +
+				`Without it every message is sent from "${EMAIL_FROM_NAME} <undefined>" and is rejected.`
+		);
+	}
+	return env.EMAIL_FROM ?? '';
+}
+
+/**
+ * Mail configuration problems, described rather than thrown.
+ *
+ * Every failure mode here is currently invisible: a missing key falls back to
+ * console mode, a missing EMAIL_FROM is refused by the provider, and both are
+ * reported only to a serverless log. Rendered on /admin/members because the
+ * commissioner is the one person who both looks at that page and can set the
+ * variable.
+ */
+export function describeMailConfig(): { ok: boolean; problems: string[] } {
+	const problems: string[] = [];
+
+	if (EMAIL_PROVIDER === 'console') {
+		if (isProduction) {
+			problems.push(
+				'EMAIL_PROVIDER is "console", so sign-in links are written to the server log instead of being emailed. Nobody can sign in.'
+			);
+		}
+	} else {
+		if (!env.EMAIL_FROM) {
+			problems.push(
+				`EMAIL_FROM is not set. Messages would be sent from "${EMAIL_FROM_NAME} <undefined>" and the provider rejects them.`
+			);
+		}
+		if (EMAIL_PROVIDER === 'resend' && !RESEND_API_KEY) {
+			problems.push(
+				'EMAIL_PROVIDER is "resend" but RESEND_API_KEY is not set, so mail silently falls back to the server log.'
+			);
+		}
+		if (EMAIL_PROVIDER === 'sendgrid' && !SENDGRID_API_KEY) {
+			problems.push(
+				'EMAIL_PROVIDER is "sendgrid" but SENDGRID_API_KEY is not set, so mail silently falls back to the server log.'
+			);
+		}
+	}
+
+	if (isProduction && !env.ORIGIN) {
+		problems.push('ORIGIN is not set, so sign-in links cannot be built.');
+	}
+
+	return { ok: problems.length === 0, problems };
+}
+
 // Optional Features
 export const SENTRY_DSN = env.SENTRY_DSN;
 export const ENABLE_ANALYTICS = env.ENABLE_ANALYTICS === 'true';

--- a/web/src/lib/server/html.test.ts
+++ b/web/src/lib/server/html.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from './html';
+
+describe('escapeHtml', () => {
+	it('escapes all five characters that can break out of a body or an attribute', () => {
+		expect(escapeHtml(`&<>"'`)).toBe('&amp;&lt;&gt;&quot;&#39;');
+	});
+
+	it('replaces the ampersand first', () => {
+		// The branch that matters. Reordering the chain so `&` runs last leaves
+		// every entity the other rules produce double-escaped — the output reads
+		// "&amp;lt;" as literal text in the mail client instead of "<".
+		expect(escapeHtml('&lt;')).toBe('&amp;lt;');
+		expect(escapeHtml('<')).toBe('&lt;');
+	});
+
+	it('renders an anchor in a rationale inert', () => {
+		// The case the doc comment describes: a proposal rationale is free text
+		// from one manager, mailed to nine others from the league's own address.
+		const escaped = escapeHtml('<a href="https://evil.example">click</a>');
+		expect(escaped).not.toContain('<a');
+		expect(escaped).not.toContain('"');
+	});
+
+	it('leaves ordinary prose untouched', () => {
+		// Guards the opposite failure: over-eager escaping mangling every
+		// proposal title that contains no markup at all.
+		const plain = 'Trade deadline moves to week 10';
+		expect(escapeHtml(plain)).toBe(plain);
+	});
+});

--- a/web/src/lib/server/html.ts
+++ b/web/src/lib/server/html.ts
@@ -1,0 +1,24 @@
+/**
+ * Escape text before it goes into an HTML email body.
+ *
+ * Proposal titles and rationales are free text written by one manager and mailed
+ * to the other nine inside a message that genuinely is from the league. Without
+ * this, a rationale containing an anchor tag is a phishing link wearing the
+ * league's own branding.
+ *
+ * The ampersand must be replaced FIRST. Move it later in the chain and every
+ * entity the other rules produce gets double-escaped, so a manager called
+ * O'Brien reads "O&amp;#39;Brien" in their mail client.
+ *
+ * Lives in its own module rather than beside the templates so that importing a
+ * seven-line string helper does not drag in the transports, env.ts and the
+ * console noise validateEnv() emits at load.
+ */
+export function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}

--- a/web/src/lib/server/notify.ts
+++ b/web/src/lib/server/notify.ts
@@ -3,6 +3,7 @@ import { db } from '$lib/server/db';
 import { dimManager, leagueMember, ruleProposal, user as userTable } from '$lib/server/db/schema';
 import { emailService, type EmailOptions } from '$lib/server/email';
 import { requireOrigin } from '$lib/server/env';
+import { escapeHtml } from '$lib/server/html';
 import { parsePreferences, type NotificationPreferences } from '$lib/server/auth-manager';
 import type { Outcome } from '$lib/server/constitution/outcome';
 
@@ -16,23 +17,6 @@ import type { Outcome } from '$lib/server/constitution/outcome';
  * 2. Log, never throw. A failed send is not a reason to turn a successful vote
  *    into a 500 for the manager who cast it.
  */
-
-/**
- * Escape text before it goes into an HTML email body.
- *
- * Proposal titles and rationales are free text written by one manager and mailed
- * to the other nine inside a message that genuinely is from the league. Without
- * this, a rationale containing an anchor tag is a phishing link wearing the
- * league's own branding.
- */
-function escapeHtml(value: string): string {
-	return value
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;')
-		.replace(/'/g, '&#39;');
-}
 
 interface Recipient {
 	email: string;
@@ -70,13 +54,27 @@ async function recipients(
 }
 
 async function fanOut(list: Recipient[], build: (to: Recipient) => EmailOptions): Promise<void> {
-	const results = await Promise.allSettled(
-		list.map((to) => emailService.sendEmail(build(to)))
-	);
+	if (list.length === 0) return;
 
-	const failed = results.filter((r) => r.status === 'rejected' || r.value === false).length;
+	// One batched request rather than one request per manager. The previous
+	// Promise.allSettled fired nine simultaneous requests at a provider whose
+	// published limit is ten per second — no headroom, shared with the login
+	// path across every API key — and reported the result as a single aggregate
+	// count, so a rate-limited fan-out and a healthy one looked identical.
+	//
+	// The tradeoff taken knowingly: batching couples the sends, so one 500 loses
+	// all nine where independent requests might have landed a few. Given the
+	// previous behaviour was silent partial failure, and given the retry and
+	// idempotency key behind this call, that is the better trade.
+	const { sent, succeeded, failed } = await emailService.sendBatch(list.map(build));
+
 	if (failed > 0) {
-		console.error(`[notify] ${failed} of ${list.length} notification emails failed to send.`);
+		// Naming the addresses is the point. A bare count tells nobody which
+		// manager never heard about the vote.
+		const missed = list.filter((_, i) => !sent[i]).map((r) => r.email);
+		console.error(
+			`[notify] ${failed} of ${list.length} notification emails failed (${succeeded} delivered): ${missed.join(', ')}`
+		);
 	}
 }
 

--- a/web/src/routes/admin/members/+page.server.ts
+++ b/web/src/routes/admin/members/+page.server.ts
@@ -5,7 +5,7 @@ import { leagueMember, user as userTable } from '$lib/server/db/schema';
 import { invalidateUserSessions } from '$lib/server/auth';
 import { requireCommissioner, getUnclaimedManagers } from '$lib/server/auth-manager';
 import { emailService, generateMagicLinkEmail } from '$lib/server/email';
-import { requireOrigin } from '$lib/server/env';
+import { describeMailConfig, requireOrigin } from '$lib/server/env';
 import { issueLoginToken } from '$lib/server/login-token';
 import { consumeLoginEmailBudget } from '$lib/server/rate-limit';
 import type { Actions, PageServerLoad } from './$types';
@@ -33,7 +33,12 @@ export const load: PageServerLoad = async ({ locals }) => {
 		members,
 		// Current managers with no allowlist row yet — the "who is still missing"
 		// list, so an unseeded manager is visible rather than silently absent.
-		unclaimed: await getUnclaimedManagers()
+		unclaimed: await getUnclaimedManagers(),
+		// Every mail misconfiguration is otherwise invisible: a missing key falls
+		// back to console mode and a missing EMAIL_FROM is refused by the
+		// provider, both reported only to a serverless log nobody reads. The
+		// commissioner is the one person who looks at this page and can fix it.
+		mailConfig: describeMailConfig()
 	};
 };
 
@@ -73,9 +78,14 @@ export const actions: Actions = {
 		// oracle to protect here — they already know who is on the roster — and
 		// silently "succeeding" on a failed send is how ten people end up unable to
 		// log in with nobody knowing why.
+		// Says "could not be confirmed", not "was not accepted". With an 8s timeout
+		// on the send, a failure here can mean the provider accepted the message
+		// and we stopped waiting — so the mail may well arrive. invitedAt stays
+		// unstamped in that case, which is the safe direction: re-inviting issues
+		// a fresh token and both links work.
 		if (!sent) {
 			return fail(502, {
-				error: `The invite to ${member.email} was not accepted by the mail provider. Check the Resend domain is verified.`
+				error: `The invite to ${member.email} could not be confirmed — the mail provider did not accept it, or did not answer in time. Check that the Resend domain is verified, then try again.`
 			});
 		}
 

--- a/web/src/routes/admin/members/+page.svelte
+++ b/web/src/routes/admin/members/+page.svelte
@@ -30,6 +30,23 @@
 		</p>
 	</header>
 
+	{#if !data.mailConfig.ok}
+		<section class="rounded-xl border border-red-600/40 bg-red-900/20 p-4">
+			<h2 class="flex items-center gap-2 text-sm font-semibold text-red-300">
+				<AlertTriangle class="h-4 w-4" /> Sign-in email is not configured
+			</h2>
+			<p class="mt-1 text-sm text-red-200/80">
+				Invites and sign-in links will not reach anyone until this is fixed. Set these in the
+				deployment's environment variables.
+			</p>
+			<ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-red-200/80">
+				{#each data.mailConfig.problems as problem}
+					<li>{problem}</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+
 	{#if form?.error}
 		<p class="rounded-lg border border-red-600/40 bg-red-900/20 p-3 text-sm text-red-300">
 			{form.error}


### PR DESCRIPTION
Audit of the Resend integration turned up four defects; interrogating the fix plan turned up a fifth. All six changes below are in one commit.

> **Root cause of non-delivery, confirmed after this PR was opened:** the sending domain `oakdalepark.xyz` is **not verified in Resend**. `POST /emails` returns 403 "Domain not verified". **Nothing in this PR fixes that** — verify the domain in Resend, or point `EMAIL_FROM` at a domain that is. This PR is hardening; that is the repair. See "Corrections" below.

**A premise correction up front:** the original audit claimed Resend's default rate limit was 2 req/s. It is **10 req/s per team**, shared across all API keys. So the nine-request fan-out was sitting on the limit with no headroom rather than certainly failing. It still had to go — when it *did* trip, the failure was silent and indistinguishable from success in the log.

## What changed

**1. Fan-out goes through the batch endpoint.** `notify.ts` now makes one `POST /emails/batch` instead of nine concurrent requests, and names the addresses that missed instead of printing a bare count. Chunked at 100, chunks sent sequentially.

Batch success is proven positively, never inferred from a 200. Resend documents same-index correspondence only for the all-success shape; the partial-failure shape is undocumented. A response that does not cover every message fails the whole chunk and logs the body verbatim — attributing ids by position across a short array would shift every index, naming the wrong managers *and* marking a failed address as sent.

The tradeoff, taken knowingly: batching couples the sends, so one 500 loses all nine. Given the previous behaviour was silent partial failure, and given the retry and idempotency key, that is the better trade.

**2. `EMAIL_FROM` is now detectable.** Unset, the header became `The League <undefined>` and every message was rejected, with only a boot warning to show for it. A guard alone could not fix this: the `EmailService` contract forbids throwing, because an exception on the login path would make provisioned addresses error while unknown ones redirect quietly — reopening the roster-enumeration oracle that flow exists to close. So `describeMailConfig()` feeds a banner on `/admin/members`, where the one person who can set the variable will actually see it.

Note that this would **not** have caught the live failure: `EMAIL_FROM` is set correctly. It is the *domain behind it* that is unverified, which no environment check can see.

**3. `displayName` is escaped in the magic-link HTML**, as `notify.ts` already did. The greeting is split in two: escaping a single shared value would have fixed the injection and made a manager called O'Brien read `O&#39;Brien` in plain text in the same edit.

**4. One retry on 429/5xx**, honouring `Retry-After`, with the same `Idempotency-Key` on both attempts so an ambiguous 5xx cannot mail twice. A non-numeric `Retry-After` falls back to a fixed delay — `Number()` on an HTTP-date is `NaN`, and `setTimeout(NaN)` fires immediately, which would turn a paced retry into an instant re-flood. 422 is never retried. `AbortSignal.timeout` at 8s, where there was no timeout at all.

**5. Error parsing is tightened — but this was oversold, see Corrections.** `describeFailure` now also handles a string-valued `error` field and is type-safe rather than relying on optional chaining through `any`. The practical output for the live 403 is unchanged.

**6. The settle race is closed.** `settleProposal` took no row lock and its updates carried no status guard, while `settleDueProposals` runs from a *page load* — two managers opening `/constitution` in the same second both settled and both mailed the league. Batching would have made that double-delivery reliable rather than flaky, so the transition is now claimed with `WHERE status = 'active' ... RETURNING`, the same atomic-claim shape as `consumeLoginToken`.

## Corrections

The commit message for this branch contains a claim that is **wrong**, kept here rather than force-pushed over:

> "Resend reports errors as {statusCode, name, message} at the top level. The old code read only body.error.message, which never matches, so an unverified sending domain surfaced as a bare HTTP 403."

The old code read ``body?.error?.message ?? body?.message ?? `HTTP ${status}` ``. That `body?.message` fallback **does** match Resend's shape, so an unverified domain was already being logged with its real message. Defect 5 as originally described did not exist. What remains in item 5 is a small robustness improvement, not a bug fix.

## Testing

40 new tests (88 total, all passing). Transports take their `fetch`, `sleep`, key generator and logger by injection, so nothing needs a network or a live key.

A spike confirmed `vi.mock('$env/dynamic/private')` works and isolates — the plan had assumed otherwise and called for splitting `email.ts` into three modules. It didn't need splitting; only `html.ts` was extracted.

`svelte-check` holds at the 2 pre-existing `D3Overview.svelte` errors. Production build succeeds.

## Follow-ups this PR does not address

- **Verify `oakdalepark.xyz` in Resend.** This is the actual fix for non-delivery.
- **`ORIGIN` may point at the wrong host.** The sign-in link in the rejected message was `https://fantasy-football-v2.vercel.app/login/verify?...`, while the site's live alias is `oakdalepark.xyz`. Links work either way, but they send managers to the vercel.app host.
- **The banner has no browser screenshot** — it renders only when misconfigured, which needs a commissioner session and a deliberately broken env. Its logic is unit-tested in `env.test.ts` instead.
- **The settle race has no unit test** — it needs two concurrent transactions. Verify by opening `/constitution` in two tabs past a deadline and confirming the league is mailed once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)