### PR TITLE
Fix the Data Dictionary: one camelCase contract for the meta-data API

### DIFF
--- a/web/src/lib/components/MetricTooltip.svelte
+++ b/web/src/lib/components/MetricTooltip.svelte
@@ -34,9 +34,15 @@
 	async function fetchMetricDefinition() {
 		if (!metricId) return;
 		
-		// Check cache first
+		// Check cache first.
+		//
+		// A page can pre-cache definitions it already has in hand (the data
+		// dictionary caches all 21 on load) without their related metrics. Such an
+		// entry has no `related_metrics` key at all, and serving it to a tooltip
+		// that wants them would silently drop the Related Metrics section, so treat
+		// it as a miss and fetch the full record.
 		const cached = metricDefinitionsStore.getMetric(metricId);
-		if (cached) {
+		if (cached && (!includeRelated || cached.related_metrics)) {
 			metricDefinition = cached.metric;
 			relatedMetrics = cached.related_metrics || [];
 			return;

--- a/web/src/lib/components/MetricTooltip.svelte
+++ b/web/src/lib/components/MetricTooltip.svelte
@@ -208,11 +208,11 @@
 					<!-- Header -->
 					<div class="border-b {theme === 'dark' ? 'border-slate-600' : 'border-gray-200'} pb-2">
 						<h3 class="font-semibold text-lg {theme === 'dark' ? 'text-white' : 'text-gray-900'}">
-							{metricDefinition.metricName || metricDefinition.metric_name}
+							{metricDefinition.metricName}
 						</h3>
-						{#if metricDefinition.categoryName || metricDefinition.category_name}
+						{#if metricDefinition.categoryName}
 							<span class="inline-block {theme === 'dark' ? 'bg-blue-900/50 text-blue-200' : 'bg-blue-100 text-blue-800'} text-xs px-2 py-1 rounded-full mt-1">
-								{metricDefinition.categoryName || metricDefinition.category_name}
+								{metricDefinition.categoryName}
 							</span>
 						{/if}
 					</div>
@@ -220,70 +220,70 @@
 					<!-- Short description -->
 					<div>
 						<p class="text-sm {theme === 'dark' ? 'text-gray-300' : 'text-gray-700'}">
-							{metricDefinition.shortDescription || metricDefinition.short_description}
+							{metricDefinition.shortDescription}
 						</p>
 					</div>
-					
+
 					<!-- Detailed description (if available) -->
-					{#if metricDefinition.detailedDescription || metricDefinition.detailed_description}
+					{#if metricDefinition.detailedDescription}
 						<div class="border-t {theme === 'dark' ? 'border-slate-600' : 'border-gray-200'} pt-2">
 							<p class="text-xs {theme === 'dark' ? 'text-slate-400' : 'text-gray-600'}">
-								{metricDefinition.detailedDescription || metricDefinition.detailed_description}
+								{metricDefinition.detailedDescription}
 							</p>
 						</div>
 					{/if}
 					
 					<!-- Calculation formula (if available) -->
-					{#if metricDefinition.calculationFormula || metricDefinition.calculation_formula}
+					{#if metricDefinition.calculationFormula}
 						<div class="{theme === 'dark' ? 'bg-slate-800' : 'bg-gray-50'} rounded p-2">
 							<h4 class="text-xs font-medium {theme === 'dark' ? 'text-slate-300' : 'text-gray-700'} mb-1">
 								Calculation:
 							</h4>
 							<code class="text-xs {theme === 'dark' ? 'text-slate-300' : 'text-gray-600'} font-mono">
-								{metricDefinition.calculationFormula || metricDefinition.calculation_formula}
+								{metricDefinition.calculationFormula}
 							</code>
 						</div>
 					{/if}
 					
 					<!-- Example calculation (if available) -->
-					{#if metricDefinition.exampleCalculation || metricDefinition.example_calculation}
+					{#if metricDefinition.exampleCalculation}
 						<div class="{theme === 'dark' ? 'bg-blue-900/30' : 'bg-blue-50'} rounded p-2">
 							<h4 class="text-xs font-medium {theme === 'dark' ? 'text-blue-300' : 'text-blue-700'} mb-1">
 								Example:
 							</h4>
 							<p class="text-xs {theme === 'dark' ? 'text-blue-200' : 'text-blue-600'}">
-								{metricDefinition.exampleCalculation || metricDefinition.example_calculation}
+								{metricDefinition.exampleCalculation}
 							</p>
 						</div>
 					{/if}
 					
 					<!-- Interpretation guide (if available) -->
-					{#if metricDefinition.interpretationGuide || metricDefinition.interpretation_guide}
+					{#if metricDefinition.interpretationGuide}
 						<div class="{theme === 'dark' ? 'bg-green-900/30' : 'bg-green-50'} rounded p-2">
 							<h4 class="text-xs font-medium {theme === 'dark' ? 'text-green-300' : 'text-green-700'} mb-1">
 								How to interpret:
 							</h4>
 							<p class="text-xs {theme === 'dark' ? 'text-green-200' : 'text-green-600'}">
-								{metricDefinition.interpretationGuide || metricDefinition.interpretation_guide}
+								{metricDefinition.interpretationGuide}
 							</p>
 						</div>
 					{/if}
 					
 					<!-- Value ranges and thresholds -->
-					{#if (metricDefinition.typicalRange || metricDefinition.typical_range) || (metricDefinition.goodValueThreshold || metricDefinition.good_value_threshold) || (metricDefinition.excellentValueThreshold || metricDefinition.excellent_value_threshold)}
+					{#if metricDefinition.typicalRange || metricDefinition.goodValueThreshold || metricDefinition.excellentValueThreshold}
 						<div class="border-t {theme === 'dark' ? 'border-slate-600' : 'border-gray-200'} pt-2">
 							<h4 class="text-xs font-medium {theme === 'dark' ? 'text-slate-300' : 'text-gray-700'} mb-1">
 								Value Ranges:
 							</h4>
 							<div class="text-xs {theme === 'dark' ? 'text-slate-400' : 'text-gray-600'} space-y-1">
-								{#if metricDefinition.typicalRange || metricDefinition.typical_range}
-									<div>Typical: {metricDefinition.typicalRange || metricDefinition.typical_range}</div>
+								{#if metricDefinition.typicalRange}
+									<div>Typical: {metricDefinition.typicalRange}</div>
 								{/if}
-								{#if metricDefinition.goodValueThreshold || metricDefinition.good_value_threshold}
-									<div>Good: {formatValue(metricDefinition.goodValueThreshold || metricDefinition.good_value_threshold, metricDefinition.displayFormat || metricDefinition.display_format)}+</div>
+								{#if metricDefinition.goodValueThreshold}
+									<div>Good: {formatValue(metricDefinition.goodValueThreshold, metricDefinition.displayFormat)}+</div>
 								{/if}
-								{#if metricDefinition.excellentValueThreshold || metricDefinition.excellent_value_threshold}
-									<div>Excellent: {formatValue(metricDefinition.excellentValueThreshold || metricDefinition.excellent_value_threshold, metricDefinition.displayFormat || metricDefinition.display_format)}+</div>
+								{#if metricDefinition.excellentValueThreshold}
+									<div>Excellent: {formatValue(metricDefinition.excellentValueThreshold, metricDefinition.displayFormat)}+</div>
 								{/if}
 							</div>
 						</div>
@@ -298,10 +298,10 @@
 							<div class="space-y-1">
 								{#each relatedMetrics.slice(0, 3) as related}
 									<div class="flex items-center space-x-2 text-xs {theme === 'dark' ? 'text-slate-400' : 'text-gray-600'}">
-										<span class="text-sm">{getRelationshipIcon(related.relationshipType || related.relationship_type)}</span>
-										<span class="font-medium">{related.relatedMetricName || related.related_metric_name}</span>
-										{#if related.relationshipDescription || related.relationship_description}
-											<span class="{theme === 'dark' ? 'text-slate-500' : 'text-gray-500'}">- {related.relationshipDescription || related.relationship_description}</span>
+										<span class="text-sm">{getRelationshipIcon(related.relationshipType)}</span>
+										<span class="font-medium">{related.relatedMetricName}</span>
+										{#if related.relationshipDescription}
+											<span class="{theme === 'dark' ? 'text-slate-500' : 'text-gray-500'}">- {related.relationshipDescription}</span>
 										{/if}
 									</div>
 								{/each}

--- a/web/src/lib/server/meta-data/normalize.test.ts
+++ b/web/src/lib/server/meta-data/normalize.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { groupByCategory, toMetric, type MetricRow } from './normalize';
+
+// Shaped like a real row off `meta_data.vw_active_metrics` *after* the client's
+// `transform: postgres.camel` has rewritten the column names. Getting this
+// fixture wrong is the whole bug, so it is written out in full once.
+function row(overrides: Partial<MetricRow> = {}): MetricRow {
+	return {
+		metricId: 'hall_of_fame_index',
+		metricName: 'Hall of Fame Index',
+		metricCategory: 'manager_performance',
+		categoryName: 'Manager Performance',
+		categoryDescription: 'Metrics that rank managers across their careers',
+		shortDescription: 'Composite score of a manager career achievements',
+		detailedDescription: 'Weighted blend of titles, win rate and longevity',
+		calculationFormula: '(championships * 40) + (win_pct * 60)',
+		exampleCalculation: '2 titles, .580 win rate -> 114.8',
+		interpretationGuide: 'Above 100 is a first-ballot career',
+		dataType: 'decimal',
+		unitOfMeasure: 'points',
+		typicalRange: '0 - 150',
+		goodValueThreshold: '75.0000',
+		excellentValueThreshold: '100.0000',
+		displayFormat: 'decimal_1',
+		sortOrder: '1',
+		categoryOrder: '1',
+		categoryIcon: 'trophy',
+		categoryColor: 'amber',
+		...overrides
+	};
+}
+
+describe('toMetric', () => {
+	it('emits the camelCase contract the page reads', () => {
+		const metric = toMetric(row());
+
+		expect(metric.metricId).toBe('hall_of_fame_index');
+		expect(metric.metricName).toBe('Hall of Fame Index');
+		expect(metric.metricCategory).toBe('manager_performance');
+		expect(metric.shortDescription).toBe('Composite score of a manager career achievements');
+		expect(metric.dataType).toBe('decimal');
+		expect(metric.unitOfMeasure).toBe('points');
+		expect(metric.typicalRange).toBe('0 - 150');
+		expect(metric.displayFormat).toBe('decimal_1');
+	});
+
+	it('leaves no field undefined', () => {
+		// The failure mode this whole change exists to prevent: Svelte renders
+		// `undefined` as an empty string, so a missing key is invisible in the
+		// markup — you get a bare "Type:" label and no error anywhere.
+		const metric = toMetric(row());
+
+		for (const [key, value] of Object.entries(metric)) {
+			expect(value, `${key} should be a value or null, never undefined`).not.toBeUndefined();
+		}
+	});
+
+	it('coerces numeric thresholds out of the strings postgres returns', () => {
+		// pg hands back NUMERIC as a string. Left alone, `formatValue` hits its
+		// default branch and prints "75.0000" where "75.0+" belongs.
+		const metric = toMetric(row());
+
+		expect(metric.goodValueThreshold).toBe(75);
+		expect(metric.excellentValueThreshold).toBe(100);
+		expect(metric.sortOrder).toBe(1);
+	});
+
+	it('maps absent optional columns to null, not undefined', () => {
+		const metric = toMetric(
+			row({
+				unitOfMeasure: null,
+				typicalRange: null,
+				goodValueThreshold: null,
+				excellentValueThreshold: null,
+				detailedDescription: null
+			})
+		);
+
+		expect(metric.unitOfMeasure).toBeNull();
+		expect(metric.typicalRange).toBeNull();
+		expect(metric.goodValueThreshold).toBeNull();
+		expect(metric.excellentValueThreshold).toBeNull();
+		expect(metric.detailedDescription).toBeNull();
+	});
+});
+
+describe('groupByCategory', () => {
+	it('splits rows into one group per category', () => {
+		// The headline symptom was "21 total metrics across 1 categories" — every
+		// row collapsing into a single bucket keyed "undefined".
+		const rows = [
+			row({ metricId: 'a', metricCategory: 'manager_performance' }),
+			row({ metricId: 'b', metricCategory: 'manager_performance' }),
+			row({
+				metricId: 'c',
+				metricCategory: 'competitiveness',
+				categoryName: 'League Competitiveness',
+				categoryIcon: 'target'
+			}),
+			row({ metricId: 'd', metricCategory: 'draft_analysis', categoryName: 'Draft Analysis' })
+		];
+
+		const groups = groupByCategory(rows);
+
+		expect(groups).toHaveLength(3);
+		expect(groups.map((g) => g.categoryId)).toEqual([
+			'manager_performance',
+			'competitiveness',
+			'draft_analysis'
+		]);
+		expect(groups[0].metrics.map((m) => m.metricId)).toEqual(['a', 'b']);
+		expect(groups.reduce((total, g) => total + g.metrics.length, 0)).toBe(4);
+	});
+
+	it('carries the category name, description and icon onto the group', () => {
+		const [group] = groupByCategory([row()]);
+
+		expect(group.categoryName).toBe('Manager Performance');
+		expect(group.categoryDescription).toBe('Metrics that rank managers across their careers');
+		// `iconName`, matching the include_categories response — the page looked up
+		// `icon_name` against a payload that said `category_icon`, so every card
+		// fell through to the default emoji.
+		expect(group.iconName).toBe('trophy');
+		expect(group.colorScheme).toBe('amber');
+	});
+
+	it('preserves the order the view returned rows in', () => {
+		// The query orders by category_order, so the first category out of the DB
+		// must be the first card on the page.
+		const groups = groupByCategory([
+			row({ metricCategory: 'record_book', categoryName: 'Record Book' }),
+			row({ metricCategory: 'manager_performance' }),
+			row({ metricCategory: 'record_book', categoryName: 'Record Book' })
+		]);
+
+		expect(groups.map((g) => g.categoryName)).toEqual(['Record Book', 'Manager Performance']);
+	});
+
+	it('falls back to the category id when the join found no category row', () => {
+		// vw_active_metrics LEFT JOINs metric_categories, so an unseeded category
+		// yields a null name. Better a raw id than a blank heading.
+		const [group] = groupByCategory([row({ categoryName: null, categoryDescription: null })]);
+
+		expect(group.categoryName).toBe('manager_performance');
+		expect(group.categoryDescription).toBeNull();
+	});
+
+	it('returns an empty list for no rows', () => {
+		expect(groupByCategory([])).toEqual([]);
+	});
+});

--- a/web/src/lib/server/meta-data/normalize.ts
+++ b/web/src/lib/server/meta-data/normalize.ts
@@ -1,0 +1,137 @@
+/**
+ * Row mappers for the meta-data (data dictionary) API.
+ *
+ * The postgres client is configured with `transform: postgres.camel`, so every
+ * row that comes back from `meta_data.vw_active_metrics` already has camelCase
+ * keys — `metricId`, not `metric_id`. These mappers name the fields explicitly
+ * rather than passing the raw row through, so the JSON contract is written down
+ * in one place instead of being whatever `SELECT *` happened to return.
+ *
+ * That distinction is not academic: the Data Dictionary page read snake_case
+ * for its whole life, got `undefined` for every field, and rendered an empty
+ * shell without anything failing loudly.
+ */
+
+/** A row off `meta_data.vw_active_metrics`, after the camelCase transform. */
+export interface MetricRow {
+	metricId: string;
+	metricName: string;
+	metricCategory: string;
+	categoryName?: string | null;
+	categoryDescription?: string | null;
+	shortDescription: string;
+	detailedDescription?: string | null;
+	calculationFormula?: string | null;
+	exampleCalculation?: string | null;
+	interpretationGuide?: string | null;
+	dataType: string;
+	unitOfMeasure?: string | null;
+	typicalRange?: string | null;
+	goodValueThreshold?: number | string | null;
+	excellentValueThreshold?: number | string | null;
+	displayFormat: string;
+	sortOrder?: number | string | null;
+	categoryOrder?: number | string | null;
+	categoryIcon?: string | null;
+	categoryColor?: string | null;
+}
+
+/** A metric as served to the browser. */
+export interface Metric {
+	metricId: string;
+	metricName: string;
+	metricCategory: string;
+	categoryName: string | null;
+	shortDescription: string;
+	detailedDescription: string | null;
+	calculationFormula: string | null;
+	exampleCalculation: string | null;
+	interpretationGuide: string | null;
+	dataType: string;
+	unitOfMeasure: string | null;
+	typicalRange: string | null;
+	goodValueThreshold: number | null;
+	excellentValueThreshold: number | null;
+	displayFormat: string;
+	sortOrder: number | null;
+}
+
+/** A category with its metrics, as served to the browser. */
+export interface CategoryGroup {
+	categoryId: string;
+	categoryName: string;
+	categoryDescription: string | null;
+	iconName: string | null;
+	colorScheme: string | null;
+	metrics: Metric[];
+}
+
+/**
+ * Numerics arrive from postgres as strings (they exceed JS number precision in
+ * the general case), so thresholds need coercing or the page formats "0.6500"
+ * as a string and `formatValue` returns it untouched.
+ */
+function toNumber(value: number | string | null | undefined): number | null {
+	if (value === null || value === undefined || value === '') return null;
+	const parsed = typeof value === 'number' ? value : Number(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function orNull(value: string | null | undefined): string | null {
+	return value ?? null;
+}
+
+export function toMetric(row: MetricRow): Metric {
+	return {
+		metricId: row.metricId,
+		metricName: row.metricName,
+		metricCategory: row.metricCategory,
+		categoryName: orNull(row.categoryName),
+		shortDescription: row.shortDescription,
+		detailedDescription: orNull(row.detailedDescription),
+		calculationFormula: orNull(row.calculationFormula),
+		exampleCalculation: orNull(row.exampleCalculation),
+		interpretationGuide: orNull(row.interpretationGuide),
+		dataType: row.dataType,
+		unitOfMeasure: orNull(row.unitOfMeasure),
+		typicalRange: orNull(row.typicalRange),
+		goodValueThreshold: toNumber(row.goodValueThreshold),
+		excellentValueThreshold: toNumber(row.excellentValueThreshold),
+		displayFormat: row.displayFormat,
+		sortOrder: toNumber(row.sortOrder)
+	};
+}
+
+/**
+ * Group rows into category cards, preserving the order the query returned them
+ * in (the view orders by category_order, sort_order, metric_name).
+ *
+ * The icon is emitted as `iconName` — the same spelling the `include_categories`
+ * response uses, since both ultimately come from `metric_categories.icon_name`.
+ * One name for one thing keeps consumers from having to guess which endpoint
+ * they were handed.
+ */
+export function groupByCategory(rows: MetricRow[]): CategoryGroup[] {
+	const groups = new Map<string, CategoryGroup>();
+
+	for (const row of rows) {
+		const categoryId = row.metricCategory;
+		let group = groups.get(categoryId);
+
+		if (!group) {
+			group = {
+				categoryId,
+				categoryName: row.categoryName ?? categoryId,
+				categoryDescription: orNull(row.categoryDescription),
+				iconName: orNull(row.categoryIcon),
+				colorScheme: orNull(row.categoryColor),
+				metrics: []
+			};
+			groups.set(categoryId, group);
+		}
+
+		group.metrics.push(toMetric(row));
+	}
+
+	return Array.from(groups.values());
+}

--- a/web/src/lib/stores/metricDefinitions.ts
+++ b/web/src/lib/stores/metricDefinitions.ts
@@ -7,33 +7,32 @@
 
 import { writable } from 'svelte/store';
 
+// camelCase throughout, matching what /api/meta-data serves. These interfaces
+// used to be snake_case and described a shape that never existed at runtime.
 interface MetricDefinition {
-    metric_id: string;
-    metric_name: string;
-    metric_category: string;
-    category_name?: string;
-    short_description: string;
-    detailed_description?: string;
-    calculation_formula?: string;
-    example_calculation?: string;
-    interpretation_guide?: string;
-    data_type: string;
-    unit_of_measure?: string;
-    typical_range?: string;
-    good_value_threshold?: number;
-    excellent_value_threshold?: number;
-    display_format: string;
-    sort_order: number;
-    category_order?: number;
-    category_icon?: string;
-    category_color?: string;
+    metricId: string;
+    metricName: string;
+    metricCategory: string;
+    categoryName?: string | null;
+    shortDescription: string;
+    detailedDescription?: string | null;
+    calculationFormula?: string | null;
+    exampleCalculation?: string | null;
+    interpretationGuide?: string | null;
+    dataType: string;
+    unitOfMeasure?: string | null;
+    typicalRange?: string | null;
+    goodValueThreshold?: number | null;
+    excellentValueThreshold?: number | null;
+    displayFormat: string;
+    sortOrder?: number | null;
 }
 
 interface RelatedMetric {
-    related_metric_id: string;
-    related_metric_name: string;
-    relationship_type: string;
-    relationship_description?: string;
+    relatedMetricId: string;
+    relatedMetricName: string;
+    relationshipType: string;
+    relationshipDescription?: string;
     strength: number;
 }
 
@@ -44,13 +43,15 @@ interface MetricData {
 }
 
 interface MetricCategory {
-    category_id: string;
-    category_name: string;
-    category_description?: string;
-    display_order: number;
-    icon_name?: string;
-    color_scheme?: string;
-    metric_count?: number;
+    categoryId: string;
+    categoryName: string;
+    categoryDescription?: string | null;
+    displayOrder?: number;
+    iconName?: string | null;
+    colorScheme?: string | null;
+    metricCount?: number;
+    // Present on the grouped default response, absent on ?include_categories=true.
+    metrics?: MetricDefinition[];
 }
 
 interface MetricDefinitionsState {
@@ -254,7 +255,7 @@ export const metricDefinitionsStore = {
 
             // Cache individual metrics
             data.metrics?.forEach((metric: MetricDefinition) => {
-                this.setMetric(metric.metric_id, { metric });
+                this.setMetric(metric.metricId, { metric });
             });
 
             return data.metrics || [];

--- a/web/src/lib/stores/metricDefinitions.ts
+++ b/web/src/lib/stores/metricDefinitions.ts
@@ -187,8 +187,12 @@ export const metricDefinitionsStore = {
                 throw new Error(data.error);
             }
 
-            // Cache the result
-            this.setMetric(metricId, data);
+            // Cache the result. An entry carries `related_metrics` only when they
+            // were actually requested — consumers use the key's presence to tell a
+            // complete record from a definition-only one, so writing the API's
+            // empty array here would make a related-less fetch masquerade as
+            // complete and starve the next caller that does want them.
+            this.setMetric(metricId, includeRelated ? data : { metric: data.metric });
 
             return {
                 metric: data.metric,

--- a/web/src/routes/api/meta-data/+server.ts
+++ b/web/src/routes/api/meta-data/+server.ts
@@ -2,69 +2,53 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { db } from '$lib/server/db';
 import { sql } from 'drizzle-orm';
+import { groupByCategory, toMetric, type MetricRow } from '$lib/server/meta-data/normalize';
 
 /**
  * Meta-data API endpoint for serving metric definitions and data dictionary
- * 
+ *
  * Supports queries for:
  * - Individual metric definitions
  * - Category listings
  * - Related metrics
  * - Field definitions for API endpoints
+ *
+ * Everything here speaks camelCase, matching the rest of the app's APIs and the
+ * shape the DB client's `transform: postgres.camel` already produces. Rows go
+ * through the mappers in $lib/server/meta-data/normalize rather than being
+ * returned raw, so the contract is explicit rather than implied by `SELECT *`.
  */
 
-interface MetricDefinition {
-    metric_id: string;
-    metric_name: string;
-    metric_category: string;
-    category_name?: string;
-    short_description: string;
-    detailed_description?: string;
-    calculation_formula?: string;
-    example_calculation?: string;
-    interpretation_guide?: string;
-    data_type: string;
-    unit_of_measure?: string;
-    typical_range?: string;
-    good_value_threshold?: number;
-    excellent_value_threshold?: number;
-    display_format: string;
-    sort_order: number;
-    category_order?: number;
-    category_icon?: string;
-    category_color?: string;
-}
-
 interface MetricCategory {
-    category_id: string;
-    category_name: string;
-    category_description?: string;
-    display_order: number;
-    icon_name?: string;
-    color_scheme?: string;
-    metric_count?: number;
+	categoryId: string;
+	categoryName: string;
+	categoryDescription?: string;
+	displayOrder: number;
+	iconName?: string;
+	colorScheme?: string;
+	metricCount?: number;
 }
 
 interface RelatedMetric {
-    related_metric_id: string;
-    related_metric_name: string;
-    relationship_type: string;
-    relationship_description?: string;
-    strength: number;
+	relatedMetricId: string;
+	relatedMetricName: string;
+	relationshipType: string;
+	relationshipDescription?: string;
+	strength: number;
 }
 
 export const GET: RequestHandler = async ({ url }) => {
-    try {
-        const metric_id = url.searchParams.get('metric_id');
-        const category = url.searchParams.get('category');
-        const endpoint = url.searchParams.get('endpoint');
-        const include_related = url.searchParams.get('include_related') === 'true';
-        const include_categories = url.searchParams.get('include_categories') === 'true';
-        
-        // If requesting categories
-        if (include_categories || (!metric_id && !category && !endpoint)) {
-            const categoriesQuery = `
-                SELECT 
+	try {
+		const metric_id = url.searchParams.get('metric_id');
+		const category = url.searchParams.get('category');
+		const endpoint = url.searchParams.get('endpoint');
+		const include_related = url.searchParams.get('include_related') === 'true';
+		const include_categories = url.searchParams.get('include_categories') === 'true';
+
+		// If requesting categories
+		if (include_categories && !metric_id && !category && !endpoint) {
+			const categoriesResult = await db.execute(sql`
+                SELECT
                     mc.category_id,
                     mc.category_name,
                     mc.category_description,
@@ -73,84 +57,70 @@ export const GET: RequestHandler = async ({ url }) => {
                     mc.color_scheme,
                     COUNT(md.metric_id) as metric_count
                 FROM meta_data.metric_categories mc
-                LEFT JOIN meta_data.metric_definitions md 
-                    ON mc.category_id = md.metric_category 
+                LEFT JOIN meta_data.metric_definitions md
+                    ON mc.category_id = md.metric_category
                     AND md.is_active = true
                 WHERE mc.is_active = true
-                GROUP BY mc.category_id, mc.category_name, mc.category_description, 
+                GROUP BY mc.category_id, mc.category_name, mc.category_description,
                          mc.display_order, mc.icon_name, mc.color_scheme
                 ORDER BY mc.display_order, mc.category_name
-            `;
-            
-            const categoriesResult = await db.execute(sql.raw(categoriesQuery));
-            const categories = Array.from(categoriesResult) as unknown as MetricCategory[];
-            
-            if (include_categories && !metric_id && !category && !endpoint) {
-                return json({ categories });
-            }
-        }
+            `);
+			const categories = Array.from(categoriesResult) as unknown as MetricCategory[];
 
-        // If requesting specific metric definition
-        if (metric_id) {
-            // Escape single quotes to prevent SQL injection
-            const escapedMetricId = metric_id.replace(/'/g, "''");
-            const metricQuery = `
-                SELECT * FROM meta_data.vw_active_metrics 
-                WHERE metric_id = '${escapedMetricId}'
-            `;
-            
-            const metricResult = await db.execute(sql.raw(metricQuery));
-            const metricArray = Array.from(metricResult) as unknown as MetricDefinition[];
-            const metric = metricArray[0];
-            
-            if (!metric) {
-                return json({ error: 'Metric not found' }, { status: 404 });
-            }
+			return json({ categories });
+		}
 
-            let relatedMetrics: RelatedMetric[] = [];
-            if (include_related) {
-                const relatedQuery = `
-                    SELECT 
+		// If requesting specific metric definition
+		if (metric_id) {
+			const metricResult = await db.execute(sql`
+                SELECT * FROM meta_data.vw_active_metrics
+                WHERE metric_id = ${metric_id}
+            `);
+			const metricArray = Array.from(metricResult) as unknown as MetricRow[];
+			const row = metricArray[0];
+
+			if (!row) {
+				return json({ error: 'Metric not found' }, { status: 404 });
+			}
+
+			let relatedMetrics: RelatedMetric[] = [];
+			if (include_related) {
+				const relatedResult = await db.execute(sql`
+                    SELECT
                         related_metric_id,
                         related_metric_name,
                         relationship_type,
                         relationship_description,
                         strength
-                    FROM meta_data.vw_metric_relationships 
-                    WHERE primary_metric_id = '${escapedMetricId}'
+                    FROM meta_data.vw_metric_relationships
+                    WHERE primary_metric_id = ${metric_id}
                     ORDER BY strength DESC, related_metric_name
-                `;
-                
-                const relatedResult = await db.execute(sql.raw(relatedQuery));
-                relatedMetrics = Array.from(relatedResult) as unknown as RelatedMetric[];
-            }
+                `);
+				relatedMetrics = Array.from(relatedResult) as unknown as RelatedMetric[];
+			}
 
-            return json({
-                metric,
-                related_metrics: relatedMetrics
-            });
-        }
+			return json({
+				metric: toMetric(row),
+				related_metrics: relatedMetrics
+			});
+		}
 
-        // If requesting metrics by category
-        if (category) {
-            const escapedCategory = category.replace(/'/g, "''");
-            const metricsQuery = `
-                SELECT * FROM meta_data.vw_active_metrics 
-                WHERE metric_category = '${escapedCategory}'
+		// If requesting metrics by category
+		if (category) {
+			const metricsResult = await db.execute(sql`
+                SELECT * FROM meta_data.vw_active_metrics
+                WHERE metric_category = ${category}
                 ORDER BY sort_order, metric_name
-            `;
-            
-            const metricsResult = await db.execute(sql.raw(metricsQuery));
-            const metrics = Array.from(metricsResult) as unknown as MetricDefinition[];
-            
-            return json({ metrics });
-        }
+            `);
+			const metrics = Array.from(metricsResult) as unknown as MetricRow[];
 
-        // If requesting field definitions for an API endpoint
-        if (endpoint) {
-            const escapedEndpoint = endpoint.replace(/'/g, "''");
-            const fieldsQuery = `
-                SELECT 
+			return json({ metrics: metrics.map(toMetric) });
+		}
+
+		// If requesting field definitions for an API endpoint
+		if (endpoint) {
+			const fieldsResult = await db.execute(sql`
+                SELECT
                     fd.field_name,
                     fd.field_description,
                     fd.is_required,
@@ -163,50 +133,26 @@ export const GET: RequestHandler = async ({ url }) => {
                     md.display_format
                 FROM meta_data.field_definitions fd
                 LEFT JOIN meta_data.metric_definitions md ON fd.metric_id = md.metric_id
-                WHERE fd.api_endpoint = '${escapedEndpoint}'
+                WHERE fd.api_endpoint = ${endpoint}
                 ORDER BY fd.field_name
-            `;
-            
-            const fieldsResult = await db.execute(sql.raw(fieldsQuery));
-            const fields = Array.from(fieldsResult);
-            
-            return json({ endpoint, fields });
-        }
+            `);
+			const fields = Array.from(fieldsResult);
 
-        // Default: return all active metrics grouped by category
-        const allMetricsQuery = `
-            SELECT * FROM meta_data.vw_active_metrics 
+			return json({ endpoint, fields });
+		}
+
+		// Default: return all active metrics grouped by category
+		const allMetricsResult = await db.execute(sql`
+            SELECT * FROM meta_data.vw_active_metrics
             ORDER BY category_order, sort_order, metric_name
-        `;
-        
-        const allMetricsResult = await db.execute(sql.raw(allMetricsQuery));
-        const allMetrics = Array.from(allMetricsResult) as unknown as MetricDefinition[];
-        
-        // Group by category
-        const groupedMetrics = allMetrics.reduce((acc, metric) => {
-            const category = metric.metric_category;
-            if (!acc[category]) {
-                acc[category] = {
-                    category_id: category,
-                    category_name: metric.category_name || category,
-                    category_icon: metric.category_icon,
-                    category_color: metric.category_color,
-                    metrics: []
-                };
-            }
-            acc[category].metrics.push(metric);
-            return acc;
-        }, {} as Record<string, any>);
+        `);
+		const allMetrics = Array.from(allMetricsResult) as unknown as MetricRow[];
 
-        return json({
-            categories: Object.values(groupedMetrics)
-        });
-
-    } catch (error) {
-        console.error('Meta-data API error:', error);
-        return json(
-            { error: 'Failed to fetch meta-data' },
-            { status: 500 }
-        );
-    }
-}; 
+		return json({
+			categories: groupByCategory(allMetrics)
+		});
+	} catch (error) {
+		console.error('Meta-data API error:', error);
+		return json({ error: 'Failed to fetch meta-data' }, { status: 500 });
+	}
+};

--- a/web/src/routes/data-dictionary/+page.svelte
+++ b/web/src/routes/data-dictionary/+page.svelte
@@ -20,21 +20,27 @@
 	
 	// Reactive filtering
 	$: filteredCategories = categories.filter((category: any) => {
-		if (selectedCategory !== 'all' && category.category_id !== selectedCategory) {
+		if (selectedCategory !== 'all' && category.categoryId !== selectedCategory) {
 			return false;
 		}
-		
+
 		if (searchTerm) {
 			const searchLower = searchTerm.toLowerCase();
-			return category.metrics.some((metric: any) => 
-				metric.metric_name.toLowerCase().includes(searchLower) ||
-				metric.short_description.toLowerCase().includes(searchLower) ||
-				metric.metric_category.toLowerCase().includes(searchLower)
-			);
+			return (category.metrics ?? []).some((metric: any) => matchesSearch(metric, searchLower));
 		}
-		
+
 		return true;
 	});
+
+	// `?? ''` rather than a bare `.toLowerCase()`: a metric missing a field should
+	// drop out of the results, not throw on the first keystroke.
+	function matchesSearch(metric: any, searchLower: string) {
+		return (
+			(metric.metricName ?? '').toLowerCase().includes(searchLower) ||
+			(metric.shortDescription ?? '').toLowerCase().includes(searchLower) ||
+			(metric.metricCategory ?? '').toLowerCase().includes(searchLower)
+		);
+	}
 	
 	onMount(async () => {
 		try {
@@ -52,15 +58,15 @@
 			}
 			
 			categories = data.categories || [];
-			
+
 			// Also cache in store for tooltip usage
+			metricDefinitionsStore.setCategories(categories);
 			categories.forEach((category: any) => {
-				metricDefinitionsStore.setCategories(categories);
 				category.metrics?.forEach((metric: any) => {
-					metricDefinitionsStore.setMetric(metric.metric_id, { metric });
+					metricDefinitionsStore.setMetric(metric.metricId, { metric });
 				});
 			});
-			
+
 		} catch (err: any) {
 			console.error('Error loading data dictionary:', err);
 			error = err.message;
@@ -71,12 +77,9 @@
 	
 	function getFilteredMetrics(categoryMetrics: any[]) {
 		if (!searchTerm) return categoryMetrics;
-		
+
 		const searchLower = searchTerm.toLowerCase();
-		return categoryMetrics.filter((metric: any) => 
-			metric.metric_name.toLowerCase().includes(searchLower) ||
-			metric.short_description.toLowerCase().includes(searchLower)
-		);
+		return categoryMetrics.filter((metric: any) => matchesSearch(metric, searchLower));
 	}
 	
 	function getCategoryIcon(iconName: string) {
@@ -177,8 +180,8 @@
 				>
 					<option value="all">All Categories</option>
 					{#each categories as category}
-						<option value={category.category_id}>
-							{getCategoryIcon(category.icon_name)} {category.category_name}
+						<option value={category.categoryId}>
+							{getCategoryIcon(category.iconName)} {category.categoryName}
 						</option>
 					{/each}
 				</select>
@@ -230,11 +233,11 @@
 						<!-- Category Header -->
 						<div class="px-6 py-4 border-b border-gray-200">
 							<div class="flex items-center space-x-3">
-								<span class="text-2xl">{getCategoryIcon(category.icon_name)}</span>
+								<span class="text-2xl">{getCategoryIcon(category.iconName)}</span>
 								<div>
-									<h2 class="text-xl font-bold text-gray-900">{category.category_name}</h2>
-									{#if category.category_description}
-										<p class="text-sm text-gray-600">{category.category_description}</p>
+									<h2 class="text-xl font-bold text-gray-900">{category.categoryName}</h2>
+									{#if category.categoryDescription}
+										<p class="text-sm text-gray-600">{category.categoryDescription}</p>
 									{/if}
 								</div>
 								<div class="ml-auto">
@@ -253,51 +256,51 @@
 										<div class="flex-1">
 											<!-- Metric Name with Tooltip -->
 											<div class="flex items-center space-x-2 mb-2">
-												<MetricTooltip metricId={metric.metric_id} position="right" maxWidth="500px">
+												<MetricTooltip metricId={metric.metricId} position="right" maxWidth="500px">
 													<h3 class="text-lg font-semibold text-gray-900 cursor-help hover:text-blue-600 transition-colors">
-														{metric.metric_name}
+														{metric.metricName}
 													</h3>
 												</MetricTooltip>
 											</div>
 											
 											<!-- Short Description -->
-											<p class="text-gray-700 mb-3">{metric.short_description}</p>
+											<p class="text-gray-700 mb-3">{metric.shortDescription}</p>
 											
 											<!-- Metadata -->
 											<div class="flex flex-wrap gap-4 text-sm text-gray-600">
 												<div class="flex items-center space-x-1">
 													<span class="font-medium">Type:</span>
-													<span class="capitalize">{metric.data_type}</span>
+													<span class="capitalize">{metric.dataType}</span>
 												</div>
-												
-												{#if metric.unit_of_measure}
+
+												{#if metric.unitOfMeasure}
 													<div class="flex items-center space-x-1">
 														<span class="font-medium">Unit:</span>
-														<span class="capitalize">{metric.unit_of_measure}</span>
+														<span class="capitalize">{metric.unitOfMeasure}</span>
 													</div>
 												{/if}
-												
-												{#if metric.typical_range}
+
+												{#if metric.typicalRange}
 													<div class="flex items-center space-x-1">
 														<span class="font-medium">Range:</span>
-														<span>{metric.typical_range}</span>
+														<span>{metric.typicalRange}</span>
 													</div>
 												{/if}
-												
-												{#if metric.good_value_threshold}
+
+												{#if metric.goodValueThreshold}
 													<div class="flex items-center space-x-1">
 														<span class="font-medium">Good:</span>
 														<span class="text-green-600">
-															{formatValue(metric.good_value_threshold, metric.display_format)}+
+															{formatValue(metric.goodValueThreshold, metric.displayFormat)}+
 														</span>
 													</div>
 												{/if}
-												
-												{#if metric.excellent_value_threshold}
+
+												{#if metric.excellentValueThreshold}
 													<div class="flex items-center space-x-1">
 														<span class="font-medium">Excellent:</span>
 														<span class="text-blue-600">
-															{formatValue(metric.excellent_value_threshold, metric.display_format)}+
+															{formatValue(metric.excellentValueThreshold, metric.displayFormat)}+
 														</span>
 													</div>
 												{/if}
@@ -307,7 +310,7 @@
 										<!-- Metric ID for developers -->
 										<div class="ml-4 text-right">
 											<code class="text-xs bg-gray-100 px-2 py-1 rounded text-gray-500">
-												{metric.metric_id}
+												{metric.metricId}
 											</code>
 										</div>
 									</div>

--- a/web/src/routes/draft/+page.svelte
+++ b/web/src/routes/draft/+page.svelte
@@ -3,7 +3,6 @@
 	import { onMount } from 'svelte';
 	import DraftBoard from '$lib/components/DraftBoard.svelte';
 	import DraftAnalysis from '$lib/components/DraftAnalysis.svelte';
-	import MetricHelp from '$lib/components/MetricHelp.svelte';
 	
 	let draftData: any = null;
 	let specificSeasonDraft: any = null;
@@ -336,26 +335,20 @@
 											</div>
 											<div>
 												<div class="text-gray-400">
-													<MetricHelp metricId="draft_steals" position="top" theme="dark" className="text-gray-400" showIcon={false}>
-														Steals
-													</MetricHelp>
+													<!-- No tooltip: steals, busts and points-per-pick have no row in
+													     meta_data.metric_definitions, and the nearest seeded metric
+													     (draft_value_score) measures something else. A plain label
+													     beats a tooltip that reads "No definition available". -->
+													Steals
 												</div>
 												<div class="font-bold text-green-400">{manager.steals}</div>
 											</div>
 											<div>
-												<div class="text-gray-400">
-													<MetricHelp metricId="draft_busts" position="top" theme="dark" className="text-gray-400" showIcon={false}>
-														Busts
-													</MetricHelp>
-												</div>
+												<div class="text-gray-400">Busts</div>
 												<div class="font-bold text-red-400">{manager.busts}</div>
 											</div>
 											<div>
-												<div class="text-gray-400">
-													<MetricHelp metricId="avg_points_per_game" position="top" theme="dark" className="text-gray-400" showIcon={false}>
-														Avg PPP
-													</MetricHelp>
-												</div>
+												<div class="text-gray-400">Avg PPP</div>
 												<div class="font-bold text-purple-400">{manager.avgPointsPerPick}</div>
 											</div>
 										</div>

--- a/web/src/routes/managers/+page.svelte
+++ b/web/src/routes/managers/+page.svelte
@@ -201,7 +201,7 @@
 								<div class="text-center">
 									<div class="text-2xl font-bold text-green-400">{parseFloat(currentManager.avgPointsPerGame || 0).toFixed(1)}</div>
 									<div class="text-slate-400 text-sm">
-										<MetricHelp metricId="avg_points_per_game" position="top" theme="dark" className="text-slate-400" showIcon={false}>
+										<MetricHelp metricId="points_per_week" position="top" theme="dark" className="text-slate-400" showIcon={false}>
 											Avg Points/Game
 										</MetricHelp>
 									</div>
@@ -278,7 +278,7 @@
 							<div class="space-y-4">
 								<div class="flex justify-between items-center">
 									<span class="text-slate-400">
-										<MetricHelp metricId="draft_value_index" position="left" theme="dark" className="text-slate-400" showIcon={false}>
+										<MetricHelp metricId="draft_value_score" position="left" theme="dark" className="text-slate-400" showIcon={false}>
 											Draft Grade
 										</MetricHelp>
 									</span>
@@ -286,7 +286,7 @@
 								</div>
 								<div class="flex justify-between items-center">
 									<span class="text-slate-400">
-										<MetricHelp metricId="faab_efficiency" position="left" theme="dark" className="text-slate-400" showIcon={false}>
+										<MetricHelp metricId="faab_efficiency_rating" position="left" theme="dark" className="text-slate-400" showIcon={false}>
 											FAAB Efficiency
 										</MetricHelp>
 									</span>

--- a/web/src/routes/managers/[slug]/+page.svelte
+++ b/web/src/routes/managers/[slug]/+page.svelte
@@ -156,7 +156,7 @@
 								{(manager.winPercentage * 100).toFixed(1)}%
 							</div>
 							<div class="text-sm text-slate-400">
-								<MetricHelp metricId="careerWinPercentage" position="bottom" theme="dark" className="text-slate-400" showIcon={false}>
+								<MetricHelp metricId="career_win_percentage" position="bottom" theme="dark" className="text-slate-400" showIcon={false}>
 									Win Rate
 								</MetricHelp>
 							</div>
@@ -168,7 +168,7 @@
 								{manager.avgPointsPerGame != null ? manager.avgPointsPerGame.toFixed(1) : '—'}
 							</div>
 							<div class="text-sm text-slate-400">
-								<MetricHelp metricId="avgPointsPerGame" position="bottom" theme="dark" className="text-slate-400" showIcon={false}>
+								<MetricHelp metricId="points_per_week" position="bottom" theme="dark" className="text-slate-400" showIcon={false}>
 									Avg Points
 								</MetricHelp>
 							</div>

--- a/web/src/routes/trades/+page.svelte
+++ b/web/src/routes/trades/+page.svelte
@@ -127,7 +127,7 @@
 						<div class="text-center">
 							<div class="text-3xl font-bold text-purple-400">{parseFloat(tradeData.analytics.overview.avgProductionImpact || 0).toFixed(1)}</div>
 							<div class="text-slate-400">
-								<MetricHelp metricId="trade_production_differential" position="top" theme="dark" className="text-slate-400" showIcon={false}>
+								<MetricHelp metricId="production_differential" position="top" theme="dark" className="text-slate-400" showIcon={false}>
 									Avg Impact
 								</MetricHelp>
 							</div>


### PR DESCRIPTION
## What was broken

`/data-dictionary` rendered an empty shell: one nameless category card with a generic 📊, "21 total metrics across 1 categories", and 21 rows each showing a bare `Type:` label and an empty ID pill.

## Why

The DB client sets `transform: postgres.camel` (`web/src/lib/server/db/index.ts:40`), which rewrites result column names for **every** query on `db`, including the raw ones in the meta-data API. Rows arrive as `metricName`/`metricCategory`; the API and the page both read `metric_name`/`metric_category`, so every field was `undefined`. Svelte renders `undefined` as an empty string, so nothing failed loudly. The grouping key was `undefined` too, which is where "1 categories" came from.

The transform predates the page (same-day commit), which is why this never worked. `MetricTooltip.svelte` had already been patched defensively for it, but nobody went back to the page.

## The fix

The transform stays: eleven other routes read camelCase rows off it. Instead the meta-data API now speaks camelCase like every other API here.

- **New `$lib/server/meta-data/normalize.ts`** with `toMetric` / `groupByCategory`. Naming the fields explicitly retires the implicit `SELECT *` contract that let this drift unnoticed. It also coerces the NUMERIC thresholds pg returns as strings, and emits `categoryDescription` (previously dropped) and `iconName` (previously spelled `category_icon` on one endpoint and `icon_name` on the other).
- **`api/meta-data/+server.ts`** routes every path through the mappers, drops the categories query that ran and was discarded on every default request, and takes its user-controlled params through `sql` template parameters instead of quote-doubled string interpolation.
- **`data-dictionary/+page.svelte`** reads camelCase, its search is null-safe (it threw on the first keystroke), and the store cache is keyed by `metricId`. It was caching all 21 metrics under `"undefined"` and poisoning its own tooltips.
- **`MetricTooltip.svelte`** loses its `camelCase || snake_case` fallback chains.
- **Six tooltips elsewhere** pointed at metric IDs never seeded into `meta_data.metric_definitions`, so they read "No definition available". Repointed to the real IDs (`careerWinPercentage` → `career_win_percentage`, `faab_efficiency` → `faab_efficiency_rating`, `draft_value_index` → `draft_value_score`, `trade_production_differential` → `production_differential`, and the "Avg Points/Game" labels → `points_per_week`). Removed the three on the draft page (steals, busts, points-per-pick) that have no seeded equivalent.

No schema or seed changes. The data was already correct; only the read path was wrong.

## Verification

- 9 new tests in `normalize.test.ts`, plus the full 167-test server suite, pass.
- Against the live DB: the page reads "21 total metrics across 12 categories" with real names, per-category icons, descriptions, types, units, ranges and thresholds. Search filters to 7 on "win". The category dropdown filters to Draft Analysis's 2 metrics. Tooltips render full definitions on both the dictionary and `/managers`. No console errors, no 404s. Every metric ID left in the codebase resolves 200.
- `npm run check` still reports 2 pre-existing d3 `this`-typing errors in `D3Overview.svelte`, untouched here.

## Judgment call worth a look

The "Avg Points/Game" tooltips on the managers pages now point at `points_per_week`. Fantasy weeks are one game each, so the seeded definition describes the displayed number, but say the word and I'll strip those two instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)