### PR TITLE
Data Dictionary depth, and one page header convention across the app

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -42,6 +42,10 @@ DATABASE_URL="$DB" npm run seed:members        # league allowlist, idempotent
 # 4. meta_data.* (data dictionary)
 psql "$DB" -f src/edw_schema/meta_data_schema.sql
 psql "$DB" -f src/edw_schema/populate_metric_definitions.sql
+# Adds the limitations column, corrects the definitions whose stored range or
+# thresholds contradicted the ETL, and rebuilds vw_active_metrics. Must run
+# after populate; idempotent, so re-running is safe.
+psql "$DB" -f src/edw_schema/add_metric_limitations.sql
 ```
 Expected counts (verification): fact_matchup 1499, fact_transaction 9691, fact_draft 3192,
 fact_player_statistics 40715, fact_team_performance 2998.

--- a/src/edw_schema/add_metric_limitations.sql
+++ b/src/edw_schema/add_metric_limitations.sql
@@ -1,0 +1,195 @@
+-- ============================================================================
+-- ADD LIMITATIONS TO METRIC DEFINITIONS
+-- ============================================================================
+-- Adds a `limitations` column to meta_data.metric_definitions and populates it
+-- for all 21 seeded metrics.
+--
+-- Every entry below is derived from the actual computation in
+-- src/edw_schema/edw_etl_processor.py, not from general knowledge of the
+-- metric. Where the stored definition contradicted the code or the data, the
+-- definition itself is corrected here rather than merely annotated.
+--
+-- Idempotent: safe to re-run.
+--
+-- Author: Luke Snow
+-- Date: 2026-08-12
+-- ============================================================================
+
+ALTER TABLE meta_data.metric_definitions
+    ADD COLUMN IF NOT EXISTS limitations TEXT;
+
+COMMENT ON COLUMN meta_data.metric_definitions.limitations IS
+    'What this metric does not capture, and where it can mislead. Grounded in the ETL implementation.';
+
+-- ============================================================================
+-- CORRECTIONS: stored text that contradicts the pipeline or the data
+-- ============================================================================
+
+-- power_score is produced by edw_etl_processor.py as
+--   win_pct*0.4 + (points/league-week max)*0.3 + (form/league-week max)*0.2 + (1-SOS)*0.1
+-- which is bounded by 0-1, not 0-100. Observed across 2,407 team-weeks:
+-- min 0.198, max 1.000, mean 0.649. The published 0-100 range and its 70/85
+-- thresholds would file every real team under "struggling".
+UPDATE meta_data.metric_definitions SET
+    calculation_formula = '(Win% × 0.4) + (Points ÷ Best Points That Week × 0.3) + (Recent Form ÷ Best Form That Week × 0.2) + ((1 − Strength of Schedule) × 0.1)',
+    example_calculation = 'Team at 70% wins, 90% of the week''s top score, 80% of the top recent form, 0.55 SOS: (0.70×0.4) + (0.90×0.3) + (0.80×0.2) + (0.45×0.1) = 0.755',
+    interpretation_guide = 'Runs 0 to 1 and is relative to the rest of the league that week. Observed league history: 0.65 is average, 0.75+ is a strong week, above 0.85 is dominant, below 0.45 is struggling.',
+    typical_range = '0.000-1.000',
+    good_value_threshold = 0.7500,
+    excellent_value_threshold = 0.8500,
+    display_format = 'decimal_3'
+WHERE metric_id = 'power_score';
+
+-- strength_of_schedule is AVG(opponent win percentage), not an average of
+-- opponent power scores, and it is not recency weighted. Observed: 0.000-1.000,
+-- mean 0.502. The published "40-90" range and "80+ is very tough" never occur.
+UPDATE meta_data.metric_definitions SET
+    detailed_description = 'The average win percentage of every opponent a team has faced. A value above 0.500 means the team drew opponents who were better than a coin flip against the rest of the league.',
+    calculation_formula = 'Average of (Opponent Win Percentage) across all games played',
+    example_calculation = 'Opponents finished 0.60, 0.45, 0.55 and 0.52: (0.60+0.45+0.55+0.52) ÷ 4 = 0.530',
+    interpretation_guide = 'Centred on 0.500 by construction. 0.550+ is a hard schedule, 0.450-0.550 is ordinary, below 0.450 is soft.',
+    unit_of_measure = 'win_percentage',
+    typical_range = '0.000-1.000',
+    display_format = 'decimal_3'
+WHERE metric_id = 'strength_of_schedule';
+
+-- season_consistency_score is a standard deviation, so lower is better. The
+-- thresholds are already stored that way (excellent < good), which is how the
+-- UI now detects the direction. Observed across 11 managers: 0.112-0.191, so
+-- the stored "0-5% is extremely consistent" band is unreachable in this league.
+UPDATE meta_data.metric_definitions SET
+    interpretation_guide = 'Lower is better. Observed league history spans 0.112 to 0.191, so read it relatively: below 0.130 is steady year to year, 0.130-0.170 is typical, above 0.170 is boom-or-bust.',
+    good_value_threshold = 0.1400,
+    excellent_value_threshold = 0.1200,
+    typical_range = '0.000-0.500'
+WHERE metric_id = 'season_consistency_score';
+
+-- competitiveness_index: observed 39.0-65.9 across 21 seasons, so the stored
+-- "excellent" threshold of 70 has never once been reached.
+UPDATE meta_data.metric_definitions SET
+    interpretation_guide = 'Higher is more competitive. Across this league''s 21 seasons the index has run 39.0 to 65.9 with a mean of 56.3, so 60+ is a genuinely tight year and below 50 is a season somebody ran away with.',
+    good_value_threshold = 55.0000,
+    excellent_value_threshold = 60.0000
+WHERE metric_id = 'competitiveness_index';
+
+-- ============================================================================
+-- LIMITATIONS
+-- ============================================================================
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Only managers with at least three seasons are ranked at all, so newer managers are absent rather than scored low. Championships are divided by the current league maximum, so every new title rescales the metric and a score from one year is not comparable to a score from another. A title and a regular season win rate are weighted the same regardless of league size, schedule strength or era.'
+WHERE metric_id = 'hall_of_fame_index';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Ties count as half a win here, but the manager analytics path computes the same field without that adjustment, so the two can disagree for managers who have tied. Every game across twenty seasons is weighted equally despite changes in league size, roster rules and scoring settings.'
+WHERE metric_id = 'career_win_percentage';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Currently reads 0.00 for every manager in this league, because no FAAB spend is recorded in the warehouse and the calculation falls back to zero rather than to null. Even with spend data the numerator is a manager''s entire career point total, not the points produced by the players actually bought with FAAB, so the metric rewards spending little more than it rewards spending well.'
+WHERE metric_id = 'faab_efficiency_rating';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Lower is better, which is the opposite direction to most metrics on this page. It is the standard deviation of weekly win percentage across a career rather than of season final records, so a manager with few seasons has an unstable value. It measures steadiness, not quality: a reliably poor manager scores as well as a reliably good one.'
+WHERE metric_id = 'season_consistency_score';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'The four components are weighted equally by choice, not because the data says they matter equally. Two of them floor at zero, so leagues past that point cannot be told apart. The playoff race component counts teams within one game of the last playoff spot and scales at ten points per team, which assumes a ten team league.'
+WHERE metric_id = 'competitiveness_index';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'The ×300 scale factor is arbitrary, picked to put ordinary leagues in a readable range. The floor at zero means any league with a win percentage spread beyond roughly a third cannot be distinguished from a worse one. It says nothing about whether the same team wins every year, only about how one season''s wins were spread.'
+WHERE metric_id = 'win_parity_score';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Uses only the highest and lowest scoring teams, so one outlier sets the score and the shape of the middle is invisible. Like win parity it floors at zero once the spread exceeds the league average.'
+WHERE metric_id = 'point_spread_score';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Uses a fixed exponent of 2. Fantasy football scoring is usually fitted nearer 2.4, so this compresses the spread between lucky and unlucky teams. When a team has no recorded points the value silently falls back to actual wins, which makes luck factor read exactly zero instead of unknown. It also assumes points scored and points allowed are independent, which head-to-head scheduling breaks.'
+WHERE metric_id = 'pythagorean_wins';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Inherits every assumption in Pythagorean wins, including the fixed exponent and the fallback that manufactures a spurious zero. Over a fourteen game season the noise is about the size of the effect, so a single season''s luck factor is not evidence of anything.'
+WHERE metric_id = 'luck_factor';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Counts only fantasy points produced after the trade. It ignores what each manager would otherwise have started, positional scarcity, and whether the player was even in the lineup, so points from a traded player who sat on a bench still count. Draft picks and FAAB included in a deal are not valued at all.'
+WHERE metric_id = 'production_differential';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Built on production differential, so it inherits its blind spots. The threshold for declaring a winner is a fixed point margin, which means trades near that line flip verdict on small scoring changes rather than on anything meaningful.'
+WHERE metric_id = 'trade_winner';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Expected points for a draft slot come from this league''s own history, so the baseline moves whenever scoring settings change and the score is not comparable to public draft value figures. A player who is drafted and immediately injured scores near zero no matter how sound the pick was at the time.'
+WHERE metric_id = 'draft_value_score';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Divides by weeks actually played, so a player who missed most of a season can post an excellent rate off a handful of games. It is not position adjusted, which makes a quarterback and a kicker incomparable on this number alone.'
+WHERE metric_id = 'points_per_week';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'The replacement baseline is derived from this league''s own waiver pool, so the values are not comparable to public VORP or PAR figures and shift with league size and roster requirements.'
+WHERE metric_id = 'points_above_replacement';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Lower is better, which is the opposite direction to most metrics on this page. Weeks with zero points are dropped from the standard deviation, so a player who missed games looks steadier than he was. It is not scale free either: high scoring positions have larger deviations by construction, which is why the thresholds are position dependent.'
+WHERE metric_id = 'consistency_rating';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Not a simulation. It is a weighted blend of current rank, games back and weeks remaining, so it does not know the specific remaining schedule, tiebreakers, or who is on which roster. The weights are fixed rather than fitted to what actually happened in past seasons.'
+WHERE metric_id = 'playoff_probability';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Points and recent form are normalised against the best team in that same league week, so the score describes standing relative to the field at that moment and cannot be compared across weeks or seasons. Where strength of schedule is missing it defaults to 0.5, which quietly pushes the schedule term to neutral rather than flagging the gap.'
+WHERE metric_id = 'power_score';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Depends on transaction records, which are sparse or entirely absent for the earliest seasons. A low value in an old season may mean the data was never captured rather than that the league was quiet.'
+WHERE metric_id = 'waiver_activity_index';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Averaging opponents'' win percentages is circular: beating your opponents lowers their win percentage and therefore lowers your own strength of schedule. Weeks with no matched opponent default to 0.500, so a team with missing games drifts toward average rather than showing a gap.'
+WHERE metric_id = 'strength_of_schedule';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'Only victories count. A manager''s largest margin in a loss records as zero rather than as a negative, so this cannot be read as a general blowout tendency. One extreme game defines the value for an entire career.'
+WHERE metric_id = 'biggest_win_margin';
+
+UPDATE meta_data.metric_definitions SET limitations =
+'A single game extreme across the whole history, so it is driven by outliers and by how many times two managers happen to have played. It says nothing about the typical margin between them.'
+WHERE metric_id = 'most_lopsided_game';
+
+-- ============================================================================
+-- REBUILD THE VIEW WITH THE NEW COLUMN
+-- ============================================================================
+
+DROP VIEW IF EXISTS meta_data.vw_active_metrics;
+
+CREATE VIEW meta_data.vw_active_metrics AS
+SELECT
+    md.metric_id,
+    md.metric_name,
+    md.metric_category,
+    mc.category_name,
+    mc.category_description,
+    md.short_description,
+    md.detailed_description,
+    md.calculation_formula,
+    md.example_calculation,
+    md.interpretation_guide,
+    md.limitations,
+    md.data_type,
+    md.unit_of_measure,
+    md.typical_range,
+    md.good_value_threshold,
+    md.excellent_value_threshold,
+    md.display_format,
+    md.sort_order,
+    mc.display_order as category_order,
+    mc.icon_name as category_icon,
+    mc.color_scheme as category_color
+FROM meta_data.metric_definitions md
+LEFT JOIN meta_data.metric_categories mc ON md.metric_category = mc.category_id
+WHERE md.is_active = TRUE
+ORDER BY mc.display_order, md.sort_order, md.metric_name;

--- a/src/edw_schema/meta_data_schema.sql
+++ b/src/edw_schema/meta_data_schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE meta_data.metric_definitions (
     calculation_formula TEXT,
     example_calculation TEXT,
     interpretation_guide TEXT,
+    limitations TEXT, -- What the metric does not capture and where it misleads
     data_type VARCHAR(20) NOT NULL, -- 'percentage', 'decimal', 'integer', 'rating', 'score'
     unit_of_measure VARCHAR(50), -- 'points', 'games', 'percentage', 'dollars', etc.
     typical_range VARCHAR(100), -- '0-100', '0.000-1.000', 'varies', etc.
@@ -226,6 +227,7 @@ SELECT
     md.calculation_formula,
     md.example_calculation,
     md.interpretation_guide,
+    md.limitations,
     md.data_type,
     md.unit_of_measure,
     md.typical_range,

--- a/web/src/lib/components/MetricTooltip.svelte
+++ b/web/src/lib/components/MetricTooltip.svelte
@@ -274,6 +274,18 @@
 							</p>
 						</div>
 					{/if}
+
+					<!-- Limitations (if available) -->
+					{#if metricDefinition.limitations}
+						<div class="{theme === 'dark' ? 'bg-amber-900/30' : 'bg-amber-50'} rounded p-2">
+							<h4 class="text-xs font-medium {theme === 'dark' ? 'text-amber-300' : 'text-amber-700'} mb-1">
+								Limitations:
+							</h4>
+							<p class="text-xs {theme === 'dark' ? 'text-amber-200' : 'text-amber-700'}">
+								{metricDefinition.limitations}
+							</p>
+						</div>
+					{/if}
 					
 					<!-- Value ranges and thresholds -->
 					{#if metricDefinition.typicalRange || metricDefinition.goodValueThreshold || metricDefinition.excellentValueThreshold}

--- a/web/src/lib/components/PageHeader.svelte
+++ b/web/src/lib/components/PageHeader.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	/**
+	 * The standard page header for every top-level route.
+	 *
+	 * The convention is the Trade Center's: a centred accent icon, a 4xl white
+	 * title, and one xl slate line of context capped at max-w-3xl. Before this
+	 * existed each page hand-rolled its own header and they drifted into four
+	 * different treatments — left-aligned rows, 5xl titles, missing icons, and
+	 * on /managers no header at all.
+	 *
+	 * Put the header in a component rather than in a style guide because a
+	 * convention nobody can accidentally deviate from is the only kind that
+	 * holds.
+	 *
+	 *   <PageHeader icon={Target} title="Trade Center" accent="amber">
+	 *       Complete trade analysis and history.
+	 *   </PageHeader>
+	 */
+	import type { ComponentType } from 'svelte';
+
+	export let title: string;
+	/** A lucide-svelte icon component. Omit for a title-only header. */
+	export let icon: ComponentType | null = null;
+	export let accent: 'amber' | 'blue' | 'green' | 'purple' | 'cyan' | 'red' = 'amber';
+
+	// Written out in full because Tailwind scans source text: an interpolated
+	// `text-${accent}-400` produces a class that never gets generated.
+	const accentClass: Record<string, string> = {
+		amber: 'text-amber-400',
+		blue: 'text-blue-400',
+		green: 'text-green-400',
+		purple: 'text-purple-400',
+		cyan: 'text-cyan-400',
+		red: 'text-red-400'
+	};
+</script>
+
+<div class="text-center py-8">
+	{#if icon}
+		<svelte:component this={icon} class="h-16 w-16 {accentClass[accent]} mx-auto mb-4" />
+	{/if}
+	<h1 class="text-4xl font-bold text-white mb-4">{title}</h1>
+	{#if $$slots.default}
+		<p class="text-xl text-slate-300 max-w-3xl mx-auto">
+			<slot />
+		</p>
+	{/if}
+</div>

--- a/web/src/lib/server/meta-data/normalize.test.ts
+++ b/web/src/lib/server/meta-data/normalize.test.ts
@@ -16,6 +16,7 @@ function row(overrides: Partial<MetricRow> = {}): MetricRow {
 		calculationFormula: '(championships * 40) + (win_pct * 60)',
 		exampleCalculation: '2 titles, .580 win rate -> 114.8',
 		interpretationGuide: 'Above 100 is a first-ballot career',
+		limitations: 'Only managers with three or more seasons are ranked',
 		dataType: 'decimal',
 		unitOfMeasure: 'points',
 		typicalRange: '0 - 150',
@@ -42,6 +43,18 @@ describe('toMetric', () => {
 		expect(metric.unitOfMeasure).toBe('points');
 		expect(metric.typicalRange).toBe('0 - 150');
 		expect(metric.displayFormat).toBe('decimal_1');
+	});
+
+	it('carries the long-form fields the dictionary page expands into', () => {
+		// These live in the DB but were never surfaced anywhere except the hover
+		// tooltip, which is why the page read as a list of vague one-liners.
+		const metric = toMetric(row());
+
+		expect(metric.detailedDescription).toBe('Weighted blend of titles, win rate and longevity');
+		expect(metric.calculationFormula).toBe('(championships * 40) + (win_pct * 60)');
+		expect(metric.exampleCalculation).toBe('2 titles, .580 win rate -> 114.8');
+		expect(metric.interpretationGuide).toBe('Above 100 is a first-ballot career');
+		expect(metric.limitations).toBe('Only managers with three or more seasons are ranked');
 	});
 
 	it('leaves no field undefined', () => {

--- a/web/src/lib/server/meta-data/normalize.ts
+++ b/web/src/lib/server/meta-data/normalize.ts
@@ -24,6 +24,7 @@ export interface MetricRow {
 	calculationFormula?: string | null;
 	exampleCalculation?: string | null;
 	interpretationGuide?: string | null;
+	limitations?: string | null;
 	dataType: string;
 	unitOfMeasure?: string | null;
 	typicalRange?: string | null;
@@ -47,6 +48,7 @@ export interface Metric {
 	calculationFormula: string | null;
 	exampleCalculation: string | null;
 	interpretationGuide: string | null;
+	limitations: string | null;
 	dataType: string;
 	unitOfMeasure: string | null;
 	typicalRange: string | null;
@@ -92,6 +94,7 @@ export function toMetric(row: MetricRow): Metric {
 		calculationFormula: orNull(row.calculationFormula),
 		exampleCalculation: orNull(row.exampleCalculation),
 		interpretationGuide: orNull(row.interpretationGuide),
+		limitations: orNull(row.limitations),
 		dataType: row.dataType,
 		unitOfMeasure: orNull(row.unitOfMeasure),
 		typicalRange: orNull(row.typicalRange),

--- a/web/src/lib/stores/metricDefinitions.ts
+++ b/web/src/lib/stores/metricDefinitions.ts
@@ -19,6 +19,7 @@ interface MetricDefinition {
     calculationFormula?: string | null;
     exampleCalculation?: string | null;
     interpretationGuide?: string | null;
+    limitations?: string | null;
     dataType: string;
     unitOfMeasure?: string | null;
     typicalRange?: string | null;

--- a/web/src/routes/chat/+page.svelte
+++ b/web/src/routes/chat/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+	import { MessageSquare } from 'lucide-svelte';
 	import ChatPanel from '$lib/components/chat/ChatPanel.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 </script>
 
 <svelte:head>
@@ -10,16 +12,13 @@
      /chat is not in PUBLIC_PREFIXES, so a signed-out visitor is redirected to
      /login before this ever renders. The panel's signed-out state exists for the
      preview embedded on the public /this-season page. -->
-<div class="space-y-4">
-	<div>
-		<h1 class="text-3xl font-bold text-white">League Chat</h1>
-		<p class="mt-1 text-sm text-slate-400">
-			Trash talk, trade offers and grievances. Reply in a thread to keep an argument
-			in one place.
-		</p>
-	</div>
+<div class="space-y-8">
+	<PageHeader icon={MessageSquare} title="League Chat">
+		Trash talk, trade offers and grievances. Reply in a thread to keep an argument in one place.
+	</PageHeader>
 
 	<!-- dvh, not vh: on mobile Safari the toolbar makes vh taller than the visible
-	     viewport, which pushes the composer off the bottom of the screen. -->
-	<ChatPanel heightClass="h-[calc(100dvh-16rem)] min-h-[24rem]" title="#general" />
+	     viewport, which pushes the composer off the bottom of the screen.
+	     The subtracted height grew with the taller shared page header. -->
+	<ChatPanel heightClass="h-[calc(100dvh-26rem)] min-h-[24rem]" title="#general" />
 </div>

--- a/web/src/routes/constitution/+page.svelte
+++ b/web/src/routes/constitution/+page.svelte
@@ -13,6 +13,7 @@
 		Vote,
 		Zap
 	} from 'lucide-svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import ClauseView from '$lib/components/constitution/ClauseView.svelte';
 	import ProposalCard from '$lib/components/constitution/ProposalCard.svelte';
 	import ProposalForm from '$lib/components/constitution/ProposalForm.svelte';
@@ -66,11 +67,17 @@
 	<title>Constitution | The League</title>
 </svelte:head>
 
-<div class="mx-auto max-w-4xl space-y-8 px-4 py-8">
+<!-- No inner container: the root layout already supplies the page gutter and max
+     width, so wrapping again double-padded this page relative to every other. -->
+<div class="space-y-8">
+	<PageHeader icon={BookOpen} title="League Constitution" accent="amber">
+		The rules this league runs on. Every clause is versioned, and changes go to a vote.
+	</PageHeader>
+
+	<!-- Body keeps a reading width; the header spans the page like everywhere else. -->
+	<div class="mx-auto max-w-4xl space-y-8">
 	<header class="text-center">
-		<BookOpen class="mx-auto mb-3 h-10 w-10 text-amber-400" />
-		<h1 class="text-3xl font-bold text-white">League Constitution</h1>
-		<div class="mt-4 flex flex-wrap items-center justify-center gap-4 text-sm">
+		<div class="flex flex-wrap items-center justify-center gap-4 text-sm">
 			<span class="flex items-center gap-2 text-slate-400">
 				<FileText class="h-4 w-4" />
 				{#if data.version}
@@ -108,7 +115,7 @@
 	{/if}
 
 	{#if myDrafts.length > 0}
-		<section class="space-y-3 rounded-xl border border-slate-600 bg-slate-800/30 p-5">
+		<section class="space-y-3 rounded-xl border border-slate-700/50 bg-slate-800/50 p-6">
 			<h2 class="flex items-center gap-2 font-semibold text-slate-300">
 				<FileText class="h-5 w-5" /> Your drafts ({myDrafts.length})
 			</h2>
@@ -218,7 +225,7 @@
 	{/if}
 
 	{#if settled.length > 0}
-		<section class="rounded-xl border border-slate-700 bg-slate-800/30 p-5">
+		<section class="rounded-xl border border-slate-700/50 bg-slate-800/50 p-6">
 			<h2 class="mb-3 font-semibold text-slate-400">Past proposals</h2>
 			<div class="space-y-3">
 				{#each settled as proposal (proposal.proposalKey)}
@@ -227,6 +234,7 @@
 			</div>
 		</section>
 	{/if}
+	</div>
 </div>
 
 {#if draft}

--- a/web/src/routes/data-dictionary/+page.svelte
+++ b/web/src/routes/data-dictionary/+page.svelte
@@ -1,23 +1,27 @@
 <script lang="ts">
 	/**
 	 * Data Dictionary Page
-	 * 
-	 * Comprehensive glossary of all metrics and definitions
-	 * Demonstrates the tooltip system and provides searchable reference
+	 *
+	 * Comprehensive glossary of all metrics and definitions.
+	 *
+	 * Each row expands to the full record the meta_data schema holds: what the
+	 * metric measures, the formula the ETL actually runs, a worked example, how
+	 * to read the number, and where it misleads. The short description alone was
+	 * not enough to tell you whether a number meant anything.
 	 */
-	
+
 	import { onMount } from 'svelte';
+	import { BookOpen, ChevronDown } from 'lucide-svelte';
 	import { metricDefinitionsStore } from '$lib/stores/metricDefinitions';
 	import MetricHelp from '$lib/components/MetricHelp.svelte';
-	import MetricTooltip from '$lib/components/MetricTooltip.svelte';
-	
+
 	let categories: any[] = [];
-	let groupedMetrics: Record<string, any> = {};
 	let searchTerm = '';
 	let selectedCategory = 'all';
 	let loading = true;
 	let error: string | null = null;
-	
+	let expanded = new Set<string>();
+
 	// Reactive filtering
 	$: filteredCategories = categories.filter((category: any) => {
 		if (selectedCategory !== 'all' && category.categoryId !== selectedCategory) {
@@ -41,22 +45,29 @@
 			(metric.metricCategory ?? '').toLowerCase().includes(searchLower)
 		);
 	}
-	
+
+	function toggle(metricId: string) {
+		// Reassigned rather than mutated so Svelte sees the change.
+		const next = new Set(expanded);
+		next.has(metricId) ? next.delete(metricId) : next.add(metricId);
+		expanded = next;
+	}
+
 	onMount(async () => {
 		try {
 			// Fetch all categories and metrics
 			const response = await fetch('/api/meta-data');
-			
+
 			if (!response.ok) {
 				throw new Error(`Failed to fetch data dictionary: ${response.status}`);
 			}
-			
+
 			const data = await response.json();
-			
+
 			if (data.error) {
 				throw new Error(data.error);
 			}
-			
+
 			categories = data.categories || [];
 
 			// Also cache in store for tooltip usage
@@ -66,7 +77,6 @@
 					metricDefinitionsStore.setMetric(metric.metricId, { metric });
 				});
 			});
-
 		} catch (err: any) {
 			console.error('Error loading data dictionary:', err);
 			error = err.message;
@@ -74,35 +84,52 @@
 			loading = false;
 		}
 	});
-	
+
 	function getFilteredMetrics(categoryMetrics: any[]) {
 		if (!searchTerm) return categoryMetrics;
 
 		const searchLower = searchTerm.toLowerCase();
 		return categoryMetrics.filter((metric: any) => matchesSearch(metric, searchLower));
 	}
-	
+
 	function getCategoryIcon(iconName: string) {
 		const icons: Record<string, string> = {
-			'user': '👤',
-			'users': '👥',
-			'target': '🎯',
-			'sword': '⚔️',
-			'exchange': '🔄',
-			'clipboard': '📋',
-			'star': '⭐',
-			'trophy': '🏆',
+			user: '👤',
+			users: '👥',
+			target: '🎯',
+			sword: '⚔️',
+			exchange: '🔄',
+			clipboard: '📋',
+			star: '⭐',
+			trophy: '🏆',
 			'chart-line': '📈',
-			'zap': '⚡',
-			'book': '📚',
-			'globe': '🌍'
+			zap: '⚡',
+			book: '📚',
+			globe: '🌍'
 		};
 		return icons[iconName] || '📊';
 	}
-	
+
+	/**
+	 * Standard deviations are stored with the excellent threshold *below* the good
+	 * one, which is the only signal in the data that says lower is better. Reading
+	 * it off the thresholds beats hardcoding a list of metric ids here.
+	 */
+	function lowerIsBetter(metric: any) {
+		return (
+			metric.goodValueThreshold != null &&
+			metric.excellentValueThreshold != null &&
+			metric.excellentValueThreshold < metric.goodValueThreshold
+		);
+	}
+
+	function formatThreshold(value: any, format: string, lower: boolean) {
+		return lower ? `≤${formatValue(value, format)}` : `${formatValue(value, format)}+`;
+	}
+
 	function formatValue(value: any, format: string) {
 		if (value === null || value === undefined) return 'N/A';
-		
+
 		switch (format) {
 			case 'percentage_1':
 				return `${(value * 100).toFixed(1)}%`;
@@ -125,208 +152,251 @@
 </script>
 
 <svelte:head>
-	<title>Data Dictionary | Fantasy Football Analytics</title>
-	<meta name="description" content="Comprehensive glossary of all fantasy football metrics and their definitions" />
+	<title>Data Dictionary | The League</title>
+	<meta
+		name="description"
+		content="Comprehensive glossary of all fantasy football metrics and their definitions"
+	/>
 </svelte:head>
 
-<div class="container mx-auto px-4 py-8 max-w-6xl">
-	<!-- Header -->
-	<div class="mb-8">
-		<h1 class="text-4xl font-bold text-gray-900 mb-4">Data Dictionary</h1>
-		<p class="text-lg text-gray-600 mb-6">
-			Comprehensive definitions for all metrics and data points used in our fantasy football analytics.
-			Hover over any metric name to see detailed information including calculations and interpretation guides.
-		</p>
-		
-		<!-- Quick demonstration -->
-		<div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-			<h3 class="font-semibold text-blue-900 mb-2">💡 How to Use Tooltips</h3>
-			<p class="text-blue-800 mb-2">
-				Throughout the application, you'll see metrics with help icons like this: 
-				<MetricHelp metricId="hall_of_fame_index" position="right">Hall of Fame Index</MetricHelp>
-			</p>
-			<p class="text-blue-700 text-sm">
-				Hover over the help icon or the metric name to see detailed definitions, calculations, and related metrics.
+<div class="space-y-8">
+	<!-- Hero -->
+	<section class="text-center py-8">
+		<div class="max-w-4xl mx-auto">
+			<BookOpen class="h-16 w-16 text-blue-400 mx-auto mb-4" />
+			<h1 class="text-4xl font-bold text-white mb-4">
+				Data <span class="text-blue-400">Dictionary</span>
+			</h1>
+			<p class="text-xl text-slate-300 leading-relaxed">
+				Every metric in this app: what it measures, the formula behind it, and where it misleads.
+				Expand any metric for the full definition.
 			</p>
 		</div>
-	</div>
-	
-	<!-- Search and Filter Controls -->
-	<div class="mb-8 bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+	</section>
+
+	<!-- Tooltip demo -->
+	<section class="bg-blue-500/10 border border-blue-500/30 rounded-xl p-5">
+		<h2 class="font-semibold text-blue-200 mb-2">💡 Metrics are explained everywhere</h2>
+		<p class="text-slate-300 mb-1">
+			Throughout the app you'll see metrics with help icons like this:
+			<MetricHelp metricId="hall_of_fame_index" position="right" theme="dark" className="text-blue-300"
+				>Hall of Fame Index</MetricHelp
+			>
+		</p>
+		<p class="text-slate-400 text-sm">
+			Hover one to get the same definition you'll find on this page, without leaving what you were
+			reading.
+		</p>
+	</section>
+
+	<!-- Search and filter -->
+	<section class="bg-slate-800/50 rounded-xl p-6 border border-slate-700/50">
 		<div class="flex flex-col md:flex-row gap-4">
-			<!-- Search -->
 			<div class="flex-1">
-				<label for="search" class="block text-sm font-medium text-gray-700 mb-2">
+				<label for="search" class="block text-sm font-medium text-slate-300 mb-2">
 					Search Metrics
 				</label>
 				<input
 					id="search"
 					type="text"
 					bind:value={searchTerm}
-					placeholder="Search by name or description..."
-					class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+					placeholder="Search by name, description or category..."
+					class="w-full bg-slate-700/50 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-blue-400"
 				/>
 			</div>
-			
-			<!-- Category Filter -->
-			<div class="md:w-64">
-				<label for="category" class="block text-sm font-medium text-gray-700 mb-2">
+
+			<div class="md:w-72">
+				<label for="category" class="block text-sm font-medium text-slate-300 mb-2">
 					Filter by Category
 				</label>
 				<select
 					id="category"
 					bind:value={selectedCategory}
-					class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+					class="w-full bg-slate-700/50 border border-slate-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-400"
 				>
 					<option value="all">All Categories</option>
 					{#each categories as category}
 						<option value={category.categoryId}>
-							{getCategoryIcon(category.iconName)} {category.categoryName}
+							{getCategoryIcon(category.iconName)}
+							{category.categoryName}
 						</option>
 					{/each}
 				</select>
 			</div>
 		</div>
-		
-		<!-- Results summary -->
+
 		{#if !loading}
-			<div class="mt-4 text-sm text-gray-600">
+			<div class="mt-4 text-sm text-slate-400">
 				{#if searchTerm || selectedCategory !== 'all'}
-					Showing {filteredCategories.reduce((total, cat) => total + getFilteredMetrics(cat.metrics || []).length, 0)} metrics
+					Showing {filteredCategories.reduce(
+						(total, cat) => total + getFilteredMetrics(cat.metrics || []).length,
+						0
+					)} metrics
 				{:else}
-					{categories.reduce((total, cat) => total + (cat.metrics?.length || 0), 0)} total metrics across {categories.length} categories
+					{categories.reduce((total, cat) => total + (cat.metrics?.length || 0), 0)} total metrics across
+					{categories.length} categories
 				{/if}
 			</div>
 		{/if}
-	</div>
-	
+	</section>
+
 	<!-- Content -->
 	{#if loading}
-		<div class="flex items-center justify-center py-12">
-			<div class="flex items-center space-x-3">
-				<div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
-				<span class="text-gray-600">Loading data dictionary...</span>
-			</div>
+		<div class="flex items-center justify-center h-64">
+			<div class="text-slate-400">Loading data dictionary...</div>
 		</div>
 	{:else if error}
-		<div class="bg-red-50 border border-red-200 rounded-lg p-6">
-			<h3 class="font-semibold text-red-900 mb-2">Error Loading Data Dictionary</h3>
-			<p class="text-red-700">{error}</p>
-		</div>
+		<section class="bg-red-500/10 border border-red-500/30 rounded-xl p-6">
+			<h2 class="font-semibold text-red-300 mb-2">Error Loading Data Dictionary</h2>
+			<p class="text-red-200">{error}</p>
+		</section>
 	{:else if filteredCategories.length === 0}
 		<div class="text-center py-12">
-			<div class="text-gray-500 mb-4">
-				<svg class="w-16 h-16 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 12h6m-6-4h6m2 5.291A7.962 7.962 0 0112 15c-2.34 0-4.5-.98-6.084-2.709M16.146 9.146a4.002 4.002 0 010 5.708m-10.292 0A4.002 4.002 0 015.146 9.146"/>
-				</svg>
-			</div>
-			<h3 class="text-lg font-medium text-gray-900 mb-2">No metrics found</h3>
-			<p class="text-gray-600">Try adjusting your search terms or category filter.</p>
+			<h2 class="text-lg font-medium text-white mb-2">No metrics found</h2>
+			<p class="text-slate-400">Try adjusting your search terms or category filter.</p>
 		</div>
 	{:else}
-		<!-- Metrics by Category -->
-		<div class="space-y-8">
+		<div class="space-y-6">
 			{#each filteredCategories as category}
 				{@const filteredMetrics = getFilteredMetrics(category.metrics || [])}
 				{#if filteredMetrics.length > 0}
-					<div class="bg-white rounded-lg shadow-sm border border-gray-200">
-						<!-- Category Header -->
-						<div class="px-6 py-4 border-b border-gray-200">
-							<div class="flex items-center space-x-3">
-								<span class="text-2xl">{getCategoryIcon(category.iconName)}</span>
-								<div>
-									<h2 class="text-xl font-bold text-gray-900">{category.categoryName}</h2>
-									{#if category.categoryDescription}
-										<p class="text-sm text-gray-600">{category.categoryDescription}</p>
-									{/if}
-								</div>
-								<div class="ml-auto">
-									<span class="bg-gray-100 text-gray-700 px-2 py-1 rounded-full text-sm">
-										{filteredMetrics.length} metric{filteredMetrics.length !== 1 ? 's' : ''}
-									</span>
-								</div>
+					<section class="bg-slate-800/50 rounded-xl border border-slate-700/50 overflow-hidden">
+						<!-- Category header -->
+						<div class="px-6 py-4 border-b border-slate-700/50 flex items-center gap-3">
+							<span class="text-2xl">{getCategoryIcon(category.iconName)}</span>
+							<div>
+								<h2 class="text-xl font-bold text-white">{category.categoryName}</h2>
+								{#if category.categoryDescription}
+									<p class="text-sm text-slate-400">{category.categoryDescription}</p>
+								{/if}
 							</div>
+							<span
+								class="ml-auto bg-slate-700/70 text-slate-300 px-2.5 py-1 rounded-full text-sm whitespace-nowrap"
+							>
+								{filteredMetrics.length} metric{filteredMetrics.length !== 1 ? 's' : ''}
+							</span>
 						</div>
-						
-						<!-- Metrics List -->
-						<div class="divide-y divide-gray-100">
+
+						<!-- Metrics -->
+						<div class="divide-y divide-slate-700/50">
 							{#each filteredMetrics as metric}
-								<div class="px-6 py-4 hover:bg-gray-50 transition-colors">
-									<div class="flex items-start justify-between">
-										<div class="flex-1">
-											<!-- Metric Name with Tooltip -->
-											<div class="flex items-center space-x-2 mb-2">
-												<MetricTooltip metricId={metric.metricId} position="right" maxWidth="500px">
-													<h3 class="text-lg font-semibold text-gray-900 cursor-help hover:text-blue-600 transition-colors">
-														{metric.metricName}
-													</h3>
-												</MetricTooltip>
-											</div>
-											
-											<!-- Short Description -->
-											<p class="text-gray-700 mb-3">{metric.shortDescription}</p>
-											
-											<!-- Metadata -->
-											<div class="flex flex-wrap gap-4 text-sm text-gray-600">
-												<div class="flex items-center space-x-1">
-													<span class="font-medium">Type:</span>
-													<span class="capitalize">{metric.dataType}</span>
+								{@const isOpen = expanded.has(metric.metricId)}
+								{@const lower = lowerIsBetter(metric)}
+								<div>
+									<button
+										type="button"
+										class="w-full text-left px-6 py-4 hover:bg-slate-700/30 transition-colors"
+										aria-expanded={isOpen}
+										on:click={() => toggle(metric.metricId)}
+									>
+										<div class="flex items-start gap-4">
+											<ChevronDown
+												class="h-5 w-5 text-slate-500 mt-1 shrink-0 transition-transform {isOpen
+													? 'rotate-180'
+													: ''}"
+											/>
+											<div class="flex-1 min-w-0">
+												<div class="flex items-baseline gap-3 flex-wrap">
+													<h3 class="text-lg font-semibold text-white">{metric.metricName}</h3>
+													<code class="text-xs bg-slate-900/70 px-2 py-0.5 rounded text-slate-400">
+														{metric.metricId}
+													</code>
 												</div>
+												<p class="text-slate-300 mt-1">{metric.shortDescription}</p>
 
-												{#if metric.unitOfMeasure}
-													<div class="flex items-center space-x-1">
-														<span class="font-medium">Unit:</span>
-														<span class="capitalize">{metric.unitOfMeasure}</span>
-													</div>
-												{/if}
-
-												{#if metric.typicalRange}
-													<div class="flex items-center space-x-1">
-														<span class="font-medium">Range:</span>
-														<span>{metric.typicalRange}</span>
-													</div>
-												{/if}
-
-												{#if metric.goodValueThreshold}
-													<div class="flex items-center space-x-1">
-														<span class="font-medium">Good:</span>
-														<span class="text-green-600">
-															{formatValue(metric.goodValueThreshold, metric.displayFormat)}+
+												<div class="flex flex-wrap gap-x-5 gap-y-1 text-sm text-slate-400 mt-2">
+													<span><span class="text-slate-500">Type:</span> {metric.dataType}</span>
+													{#if metric.unitOfMeasure}
+														<span
+															><span class="text-slate-500">Unit:</span>
+															{metric.unitOfMeasure}</span
+														>
+													{/if}
+													{#if metric.typicalRange}
+														<span
+															><span class="text-slate-500">Range:</span> {metric.typicalRange}</span
+														>
+													{/if}
+													{#if metric.goodValueThreshold != null}
+														<span>
+															<span class="text-slate-500">Good:</span>
+															<span class="text-green-400"
+																>{formatThreshold(
+																	metric.goodValueThreshold,
+																	metric.displayFormat,
+																	lower
+																)}</span
+															>
 														</span>
-													</div>
-												{/if}
-
-												{#if metric.excellentValueThreshold}
-													<div class="flex items-center space-x-1">
-														<span class="font-medium">Excellent:</span>
-														<span class="text-blue-600">
-															{formatValue(metric.excellentValueThreshold, metric.displayFormat)}+
+													{/if}
+													{#if metric.excellentValueThreshold != null}
+														<span>
+															<span class="text-slate-500">Excellent:</span>
+															<span class="text-blue-400"
+																>{formatThreshold(
+																	metric.excellentValueThreshold,
+																	metric.displayFormat,
+																	lower
+																)}</span
+															>
 														</span>
-													</div>
-												{/if}
+													{/if}
+													{#if lower}
+														<span class="text-amber-400/90">Lower is better</span>
+													{/if}
+												</div>
 											</div>
 										</div>
-										
-										<!-- Metric ID for developers -->
-										<div class="ml-4 text-right">
-											<code class="text-xs bg-gray-100 px-2 py-1 rounded text-gray-500">
-												{metric.metricId}
-											</code>
+									</button>
+
+									{#if isOpen}
+										<div class="px-6 pb-5 pl-15 space-y-4">
+											{#if metric.detailedDescription}
+												<p class="text-slate-300 leading-relaxed">{metric.detailedDescription}</p>
+											{/if}
+
+											{#if metric.calculationFormula}
+												<div class="bg-slate-900/60 border border-slate-700/50 rounded-lg p-4">
+													<h4 class="text-xs font-semibold uppercase tracking-wide text-slate-500 mb-2">
+														Calculation
+													</h4>
+													<code class="text-sm text-slate-200 font-mono break-words">
+														{metric.calculationFormula}
+													</code>
+													{#if metric.exampleCalculation}
+														<p class="text-sm text-slate-400 mt-3 pt-3 border-t border-slate-700/50">
+															<span class="text-slate-500">Worked example: </span>
+															{metric.exampleCalculation}
+														</p>
+													{/if}
+												</div>
+											{/if}
+
+											{#if metric.interpretationGuide}
+												<div class="bg-green-500/5 border border-green-500/20 rounded-lg p-4">
+													<h4 class="text-xs font-semibold uppercase tracking-wide text-green-400/80 mb-2">
+														How to read it
+													</h4>
+													<p class="text-sm text-slate-300">{metric.interpretationGuide}</p>
+												</div>
+											{/if}
+
+											{#if metric.limitations}
+												<div class="bg-amber-500/5 border border-amber-500/20 rounded-lg p-4">
+													<h4 class="text-xs font-semibold uppercase tracking-wide text-amber-400/80 mb-2">
+														Limitations
+													</h4>
+													<p class="text-sm text-slate-300">{metric.limitations}</p>
+												</div>
+											{/if}
 										</div>
-									</div>
+									{/if}
 								</div>
 							{/each}
 						</div>
-					</div>
+					</section>
 				{/if}
 			{/each}
 		</div>
 	{/if}
 </div>
-
-<style>
-	/* Ensure tooltips work properly in this page */
-	:global(.container) {
-		position: relative;
-	}
-</style> 

--- a/web/src/routes/data-dictionary/+page.svelte
+++ b/web/src/routes/data-dictionary/+page.svelte
@@ -14,6 +14,7 @@
 	import { BookOpen, ChevronDown } from 'lucide-svelte';
 	import { metricDefinitionsStore } from '$lib/stores/metricDefinitions';
 	import MetricHelp from '$lib/components/MetricHelp.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 
 	let categories: any[] = [];
 	let searchTerm = '';
@@ -160,26 +161,17 @@
 </svelte:head>
 
 <div class="space-y-8">
-	<!-- Hero -->
-	<section class="text-center py-8">
-		<div class="max-w-4xl mx-auto">
-			<BookOpen class="h-16 w-16 text-blue-400 mx-auto mb-4" />
-			<h1 class="text-4xl font-bold text-white mb-4">
-				Data <span class="text-blue-400">Dictionary</span>
-			</h1>
-			<p class="text-xl text-slate-300 leading-relaxed">
-				Every metric in this app: what it measures, the formula behind it, and where it misleads.
-				Expand any metric for the full definition.
-			</p>
-		</div>
-	</section>
+	<PageHeader icon={BookOpen} title="Data Dictionary">
+		Every metric in this app: what it measures, the formula behind it, and where it misleads. Expand
+		any metric for the full definition.
+	</PageHeader>
 
 	<!-- Tooltip demo -->
-	<section class="bg-blue-500/10 border border-blue-500/30 rounded-xl p-5">
-		<h2 class="font-semibold text-blue-200 mb-2">💡 Metrics are explained everywhere</h2>
+	<section class="bg-amber-500/10 border border-amber-500/30 rounded-xl p-5">
+		<h2 class="font-semibold text-amber-200 mb-2">💡 Metrics are explained everywhere</h2>
 		<p class="text-slate-300 mb-1">
 			Throughout the app you'll see metrics with help icons like this:
-			<MetricHelp metricId="hall_of_fame_index" position="right" theme="dark" className="text-blue-300"
+			<MetricHelp metricId="hall_of_fame_index" position="right" theme="dark" className="text-amber-300"
 				>Hall of Fame Index</MetricHelp
 			>
 		</p>
@@ -201,7 +193,7 @@
 					type="text"
 					bind:value={searchTerm}
 					placeholder="Search by name, description or category..."
-					class="w-full bg-slate-700/50 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-blue-400"
+					class="w-full bg-slate-700/50 border border-slate-600 rounded-lg px-3 py-2 text-white placeholder-slate-400 focus:outline-none focus:border-amber-400"
 				/>
 			</div>
 
@@ -212,7 +204,7 @@
 				<select
 					id="category"
 					bind:value={selectedCategory}
-					class="w-full bg-slate-700/50 border border-slate-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-400"
+					class="w-full bg-slate-700/50 border border-slate-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-amber-400"
 				>
 					<option value="all">All Categories</option>
 					{#each categories as category}

--- a/web/src/routes/draft/+page.svelte
+++ b/web/src/routes/draft/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import DraftBoard from '$lib/components/DraftBoard.svelte';
 	import DraftAnalysis from '$lib/components/DraftAnalysis.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	
 	let draftData: any = null;
 	let specificSeasonDraft: any = null;
@@ -260,14 +261,10 @@
 </svelte:head>
 
 <div class="space-y-8">
-	<!-- Page Header -->
-	<div class="text-center py-8">
-		<Trophy class="h-16 w-16 text-amber-400 mx-auto mb-4" />
-		<h1 class="text-4xl font-bold text-white mb-4">Draft Central</h1>
-		<p class="text-xl text-slate-300 max-w-3xl mx-auto">
-			Complete draft history and analysis. Explore draft boards, manager performance, and value picks across all seasons.
-		</p>
-	</div>
+	<PageHeader icon={Trophy} title="Draft Central" accent="amber">
+		Complete draft history and analysis. Explore draft boards, manager performance, and value picks
+		across all seasons.
+	</PageHeader>
 
 	<!-- Draft Content -->
 	<section class="bg-slate-800/50 rounded-xl p-6 border border-slate-700/50">

--- a/web/src/routes/hall-of-fame/+page.svelte
+++ b/web/src/routes/hall-of-fame/+page.svelte
@@ -3,6 +3,7 @@
 	import { Crown, Trophy, Target, TrendingUp, Award, BarChart3, Users, Medal } from 'lucide-svelte';
 	import ManagerProfilePicture from '$lib/components/ManagerProfilePicture.svelte';
 	import MetricHelp from '$lib/components/MetricHelp.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	
 	let hallOfFameData: any = null;
 	let loading = true;
@@ -82,18 +83,10 @@
 </svelte:head>
 
 <div class="space-y-8">
-	<!-- Hero Section -->
-	<section class="text-center py-8">
-		<div class="max-w-4xl mx-auto">
-			<Crown class="h-16 w-16 text-amber-400 mx-auto mb-4" />
-			<h1 class="text-4xl font-bold text-white mb-4">
-				The League <span class="text-amber-400">Hall of Fame</span>
-			</h1>
-			<p class="text-xl text-slate-300 leading-relaxed">
-				Celebrating the greatest managers in league history. Based on championships, consistency, and overall excellence.
-			</p>
-		</div>
-	</section>
+	<PageHeader icon={Crown} title="Hall of Fame" accent="amber">
+		Celebrating the greatest managers in league history. Based on championships, consistency, and
+		overall excellence.
+	</PageHeader>
 
 	{#if loading}
 		<div class="flex items-center justify-center h-64">

--- a/web/src/routes/historical/+page.svelte
+++ b/web/src/routes/historical/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { BarChart3, TrendingUp, Trophy, Users, Target, Calendar, Zap } from 'lucide-svelte';
+	import { BarChart3, TrendingUp, Trophy, Users, Target, Calendar, Zap, History } from 'lucide-svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { onMount } from 'svelte';
 	import ClientOnlyD3Overview from '$lib/components/ClientOnlyD3Overview.svelte';
 	import MetricHelp from '$lib/components/MetricHelp.svelte';
@@ -302,14 +303,10 @@
 </script>
 
 <div class="space-y-8">
-	<!-- Page Header -->
-	<div class="text-center py-8">
-		<h1 class="text-5xl font-bold text-white mb-4">Historical Deep Dive</h1>
-		<p class="text-xl text-slate-300 max-w-3xl mx-auto">
-			Explore {ovSeasons ?? 20}+ years of fantasy football history. Trades, head-to-head matchups,
-			league evolution, and championship moments analyzed and visualized.
-		</p>
-	</div>
+	<PageHeader icon={History} title="Historical Deep Dive" accent="amber">
+		Explore {ovSeasons ?? 20}+ years of fantasy football history. Trades, head-to-head matchups,
+		league evolution, and championship moments analyzed and visualized.
+	</PageHeader>
 
 	<!-- Tab Navigation -->
 	<div class="flex flex-wrap justify-center gap-2 bg-slate-800/30 p-2 rounded-xl">

--- a/web/src/routes/managers/+page.svelte
+++ b/web/src/routes/managers/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { Trophy, Target, TrendingUp, Award, User, Crown, BarChart3, Calendar, Users } from 'lucide-svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import ManagerProfilePicture from '$lib/components/ManagerProfilePicture.svelte';
 	import MetricHelp from '$lib/components/MetricHelp.svelte';
 	import { getTierColor, getWinPercentageColor, getChampionshipBadge, getInitials } from '$lib/utils/managerUtils';
@@ -56,10 +57,24 @@
 	}
 </script>
 
-<div class="min-h-screen bg-slate-900 flex">
+<svelte:head>
+	<title>Managers - The League</title>
+</svelte:head>
+
+<div class="space-y-8">
+	<PageHeader icon={Users} title="Managers">
+		Career records, championships and season-by-season history for every manager in the league.
+	</PageHeader>
+
+	<!-- The selector/profile split is this page's own layout, but it now sits in
+	     the same panel treatment every other page uses instead of bleeding to the
+	     window edges. -->
+	<div
+		class="flex bg-slate-800/50 rounded-xl border border-slate-700/50 overflow-hidden min-h-[32rem]"
+	>
 	{#if loading}
-		<div class="flex items-center justify-center w-full h-screen">
-			<div class="text-2xl text-slate-400">Loading manager profiles...</div>
+		<div class="flex items-center justify-center w-full h-64">
+			<div class="text-slate-400">Loading manager profiles...</div>
 		</div>
 	{:else if currentManager}
 		<!-- Left Sidebar - Manager Selector (desktop) -->
@@ -362,8 +377,9 @@
 			</div>
 		</div>
 	{:else}
-		<div class="flex items-center justify-center w-full h-screen">
-			<div class="text-2xl text-slate-400">No manager data available</div>
+		<div class="flex items-center justify-center w-full h-64">
+			<div class="text-slate-400">No manager data available</div>
 		</div>
 	{/if}
+	</div>
 </div>

--- a/web/src/routes/power-rankings/+page.svelte
+++ b/web/src/routes/power-rankings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { TrendingUp, TrendingDown, Minus, Trophy, Info } from 'lucide-svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import type { PowerRankingRow } from '../api/power-rankings/+server';
 
 	let loading = $state(true);
@@ -156,45 +157,39 @@
 </svelte:head>
 
 <div class="space-y-8">
-	<div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-		<div>
-			<h1 class="text-4xl font-bold text-white mb-2">Power Rankings</h1>
-			<p class="text-slate-400">
-				Ranked by power score, which blends record, scoring and recent form —
-				not by standings alone.
-			</p>
+	<PageHeader icon={TrendingUp} title="Power Rankings">
+		Ranked by power score, which blends record, scoring and recent form, not by standings alone.
+	</PageHeader>
+
+	{#if seasons.length > 0}
+		<div class="flex flex-wrap items-center gap-4 bg-slate-800/30 rounded-lg p-4">
+			<label class="text-slate-300 font-medium">
+				Season
+				<select
+					class="ml-2 bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none"
+					value={season}
+					onchange={onSeasonChange}
+				>
+					{#each seasons as s}
+						<option value={s}>{s}</option>
+					{/each}
+				</select>
+			</label>
+
+			<label class="text-slate-300 font-medium">
+				Week <span class="text-slate-500 font-normal">(regular season)</span>
+				<select
+					class="ml-2 bg-slate-700 text-white px-3 py-2 rounded border border-slate-600 focus:border-amber-400 focus:outline-none"
+					value={week}
+					onchange={onWeekChange}
+				>
+					{#each weeks as w}
+						<option value={w}>Week {w}</option>
+					{/each}
+				</select>
+			</label>
 		</div>
-
-		{#if seasons.length > 0}
-			<div class="flex items-end gap-3">
-				<label class="flex flex-col text-xs font-medium text-slate-400">
-					Season
-					<select
-						class="mt-1 rounded-lg border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-white focus:border-amber-500 focus:outline-none"
-						value={season}
-						onchange={onSeasonChange}
-					>
-						{#each seasons as s}
-							<option value={s}>{s}</option>
-						{/each}
-					</select>
-				</label>
-
-				<label class="flex flex-col text-xs font-medium text-slate-400">
-					Week <span class="text-slate-500">(regular season)</span>
-					<select
-						class="mt-1 rounded-lg border border-slate-600 bg-slate-800 px-3 py-2 text-sm text-white focus:border-amber-500 focus:outline-none"
-						value={week}
-						onchange={onWeekChange}
-					>
-						{#each weeks as w}
-							<option value={w}>Week {w}</option>
-						{/each}
-					</select>
-				</label>
-			</div>
-		{/if}
-	</div>
+	{/if}
 
 	{#if loading}
 		<div class="space-y-3">

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { Bell, Mail, Shield, User } from 'lucide-svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import type { ActionData, PageData } from './$types';
 
 	export let data: PageData;
@@ -13,8 +14,12 @@
 	<title>Settings | The League</title>
 </svelte:head>
 
-<div class="mx-auto max-w-2xl space-y-6 px-4 py-8">
-	<h1 class="text-2xl font-bold text-white">Settings</h1>
+<div class="space-y-8">
+	<PageHeader icon={User} title="Settings" accent="amber">
+		Your profile and how the league gets in touch with you.
+	</PageHeader>
+
+	<div class="mx-auto max-w-2xl space-y-6">
 
 	{#if data.manager}
 		<section class="rounded-xl border border-slate-700 bg-slate-800/50 p-6">
@@ -122,4 +127,5 @@
 			Your account isn't linked to a manager profile. Ask the commissioner to check the roster.
 		</p>
 	{/if}
+	</div>
 </div>

--- a/web/src/routes/this-season/+page.svelte
+++ b/web/src/routes/this-season/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Calendar, Trophy, TrendingUp, ExternalLink, Users, Target } from 'lucide-svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import MetricHelp from '$lib/components/MetricHelp.svelte';
@@ -143,29 +144,34 @@
 </script>
 
 <div class="space-y-8">
-	<!-- Page Header -->
-	<div class="flex items-center justify-between">
-		<div>
-			<h1 class="text-4xl font-bold text-white mb-2">This Season</h1>
-			<p class="text-slate-400">
-				Week {currentWeek} • 
-				{currentWeek >= 17 ? 'Season Complete' : 
-				 currentWeek >= 14 ? 'Playoffs are heating up' : 
-				 currentWeek >= 10 ? 'Trade deadline passed' : 
-				 'Regular season in progress'}
-			</p>
+	<PageHeader icon={Calendar} title="This Season">
+		Live standings, matchups and the playoff picture as the season plays out.
+	</PageHeader>
+
+	<!-- Status bar: the Trade Center's filter-bar treatment, which is where
+	     page-level context and controls live. -->
+	<div class="flex flex-wrap items-center justify-between gap-3 bg-slate-800/30 rounded-lg p-4">
+		<div class="text-slate-300 font-medium">
+			Week {currentWeek} <span class="text-slate-500">•</span>
+			<span class="text-slate-400">
+				{currentWeek >= 17
+					? 'Season Complete'
+					: currentWeek >= 14
+						? 'Playoffs are heating up'
+						: currentWeek >= 10
+							? 'Trade deadline passed'
+							: 'Regular season in progress'}
+			</span>
 		</div>
-		<div class="flex items-center space-x-4">
-			<a
-				href={YAHOO_LEAGUE_URL}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg font-medium flex items-center"
-			>
-				<ExternalLink class="w-4 h-4 mr-2" />
-				Yahoo League
-			</a>
-		</div>
+		<a
+			href={YAHOO_LEAGUE_URL}
+			target="_blank"
+			rel="noopener noreferrer"
+			class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg font-medium flex items-center"
+		>
+			<ExternalLink class="w-4 h-4 mr-2" />
+			Yahoo League
+		</a>
 	</div>
 
 	<div class="grid grid-cols-1 lg:grid-cols-3 gap-8">

--- a/web/src/routes/trades/+page.svelte
+++ b/web/src/routes/trades/+page.svelte
@@ -2,6 +2,7 @@
 	import { TrendingUp, Trophy, Calendar, BarChart3, Target } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import MetricHelp from '$lib/components/MetricHelp.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	
 	let tradeData: any = null;
 	let loading = true;
@@ -65,15 +66,10 @@
 </svelte:head>
 
 <div class="space-y-8">
-	<!-- Page Header -->
-	<div class="text-center py-8">
-		<Target class="h-16 w-16 text-amber-400 mx-auto mb-4" />
-		<h1 class="text-4xl font-bold text-white mb-4">Trade Center</h1>
-		<p class="text-xl text-slate-300 max-w-3xl mx-auto">
-			Complete trade analysis and history. Explore deal winners, championship impact trades, 
-			and comprehensive transaction analytics across all seasons.
-		</p>
-	</div>
+	<PageHeader icon={Target} title="Trade Center" accent="amber">
+		Complete trade analysis and history. Explore deal winners, championship impact trades, and
+		comprehensive transaction analytics across all seasons.
+	</PageHeader>
 
 	<!-- Trade Analysis Content -->
 	{#if loadingTrades}


### PR DESCRIPTION
Follows #44, which is merged. Two commits.

## 1. Data Dictionary depth

The page was a white-card layout on a dark site, and each metric showed only a one-line description that never said how the number was computed or when to distrust it.

Styling now matches the app, and rows expand instead of relying on hover, so the detail is reachable on touch and readable at length.

The long-form fields already existed in `meta_data` and were only ever visible in a hover tooltip. Expanding a metric now shows the detailed description, the formula the ETL actually runs, a worked example, how to read the value, and its limitations.

**Limitations are new**, and each is written from the implementation in `edw_etl_processor.py` rather than from general knowledge of the metric — the three-season cutoff on the Hall of Fame index, the fixed exponent of 2 in Pythagorean wins, the zero floor that makes unbalanced leagues indistinguishable on win parity, the circularity in averaging opponents' win percentages.

**Checking each formula against the warehouse turned up stored text that contradicted the pipeline**, so this corrects rather than annotates:

- `power_score` is bounded 0–1 by its own formula and runs 0.198–1.000 across 2,407 team-weeks. It was documented as 0–100 with 70/85 thresholds, which filed every real team under "struggling".
- `strength_of_schedule` is the average of opponent *win percentages*, not opponent power scores, and isn't recency weighted. Documented as "40–90" where the observed range is 0.000–1.000 around a mean of 0.502.
- `season_consistency_score` and `competitiveness_index` carried thresholds no manager or season in twenty years has reached.

Thresholds for lower-is-better metrics render as `≤0.140` with a "Lower is better" marker, read off the stored thresholds (excellent below good) rather than a hardcoded list.

### Worth a separate look

`faab_efficiency_rating` reads exactly 0.00 for all 11 managers: no FAAB spend is recorded in the warehouse, and the ETL's `ELSE 0` turns that into a real-looking zero instead of null. It's displayed on the Managers page as "FAAB Efficiency". That's a data-capture problem rather than a dictionary one, so the pipeline is untouched and the metric's limitations text says so.

### Migration

`src/edw_schema/add_metric_limitations.sql` is idempotent and wired into the RUNBOOK after `populate_metric_definitions.sql`. `meta_data_schema.sql` also declares the column now, so a database built from the schema file matches one built from schema plus migration. **Applied to local; Neon still needs it.**

## 2. One page header convention

The top-level pages had drifted into four treatments: centred hero with an amber icon (Trade Center, Draft), centred with no icon and a 5xl title (Historical), left-aligned rows with controls in the header (This Season, Power Rankings), and a smaller variant in its own container (Constitution, Chat, Settings). Managers had no header at all.

Trade Center is the branding, so it's now a component rather than a pattern to copy: `PageHeader` renders the centred amber icon, the 4xl white title, and one xl slate line at `max-w-3xl`. Amber is the default and every page uses it — the yellow against the blue background is the look.

Also folded in:

- **Managers** gets a header, a title, and the standard panel treatment. It was `min-h-screen bg-slate-900 flex`, bleeding to the window edges and ignoring the layout's gutter.
- Controls that lived inside header rows move to the Trade Center's filter-bar treatment: the Yahoo link and week status on This Season, the season and week selects on Power Rankings.
- **Constitution** and **Settings** drop their own `mx-auto` containers, which double-padded them against the root layout. Both keep a reading-width wrapper for the body.
- Managers' loading and empty states match the rest (`h-64`, `text-slate-400`, not `h-screen` and `text-2xl`).

## Verification

- 168 server tests pass. `npm run check` is unchanged at 2 pre-existing d3 `this`-typing errors in `D3Overview.svelte`.
- All 11 top-level pages return 200 and render the shared header with the amber icon.
- Data Dictionary verified against the live DB: 21 metrics across 12 categories, search and category filter work, expansion shows all five sections, tooltips resolve.

## One judgment call

Chat's panel height is a `calc(100dvh - …)` expression and the shared header is taller than the one it replaced, so I widened the subtraction from 16rem to 26rem. There's a `min-h-[24rem]` floor so it can't collapse, but I picked that number by reasoning about the header's height rather than measuring on a real device. Worth checking on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)