### PR TITLE
Point the Yahoo league link at the evergreen slug

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -18,8 +18,10 @@ RESEND_API_KEY=
 EMAIL_FROM=league@yourdomain.com
 EMAIL_FROM_NAME=The League
 
-# The Yahoo league everyone is currently playing in. Changes every August, when
-# Yahoo issues a new league number for the new season. Not derived from
-# edw.dim_league on purpose: the warehouse trails Yahoo by a season, so deriving
-# it would point the whole league at last year until the ETL catches up.
-PUBLIC_YAHOO_LEAGUE_URL=https://football.fantasysports.yahoo.com/f1/744846
+# The Yahoo league everyone is currently playing in. The league-name slug is
+# evergreen — it follows the league into each new season, unlike the /f1/<number>
+# URL, whose number Yahoo reissues every August. Override only to point a local
+# build at a different league. Not derived from edw.dim_league on purpose: the
+# warehouse trails Yahoo by a season, so deriving it would point the whole league
+# at last year until the ETL catches up.
+PUBLIC_YAHOO_LEAGUE_URL=https://football.fantasysports.yahoo.com/league/oakdale_park

--- a/web/src/lib/config/league.ts
+++ b/web/src/lib/config/league.ts
@@ -3,14 +3,17 @@ import { env } from '$env/dynamic/public';
 /**
  * The Yahoo league people are actually playing in.
  *
- * Deliberately configuration rather than something derived from `edw.dim_league`.
- * The ETL's newest season is 2025 (`461.l.654923`), while the active league is
- * 744846 — a season Yahoo has but the warehouse has not ingested yet. Deriving
- * this from the warehouse would point everyone at last year for the whole
- * preseason, every year.
+ * Yahoo's league-name slug (`/league/oakdale_park`) rather than a numbered
+ * `/f1/<number>` URL: the number is reissued every August for the new season,
+ * the slug is not. It always resolves to the current season's league, so this
+ * needs no maintenance and cannot go stale mid-preseason.
+ *
+ * Deliberately configuration rather than something derived from `edw.dim_league`,
+ * whose newest season is 2025 (`461.l.654923`) — the warehouse trails Yahoo by a
+ * season, so deriving this would point everyone at last year all preseason.
  *
  * `$env/dynamic/public` rather than `$env/static/public` so an unset variable
  * falls back instead of failing the build.
  */
 export const YAHOO_LEAGUE_URL =
-	env.PUBLIC_YAHOO_LEAGUE_URL || 'https://football.fantasysports.yahoo.com/f1/744846';
+	env.PUBLIC_YAHOO_LEAGUE_URL || 'https://football.fantasysports.yahoo.com/league/oakdale_park';


### PR DESCRIPTION
## What

The **Yahoo League** button on `/this-season` pointed at `/f1/744846`. Yahoo reissues that league number every August for the new season, so the link needed a manual update each preseason or it would quietly point at a dead league.

Yahoo also serves the league under its name slug — `https://football.fantasysports.yahoo.com/league/oakdale_park` — which follows the league into each new season. Same destination, no annual maintenance.

## Changes

- `web/src/lib/config/league.ts` — fallback is now the slug URL; comment explains why the slug is preferred over the number
- `web/.env.example` — same value, and the comment no longer tells the reader this needs an August update

## Not changed

- `yahooArchiveUrl` in `web/src/lib/utils/yahoo.ts` still builds `/archive/nfl/<year>/<number>` per season. The slug only resolves to the *current* league, so it can't stand in for the 21 historical seasons. That helper remains unwired pending the login-gated URL check its comment describes.
- `weekly_extractor.py` builds `/f1/<league_id>` for whatever leagues the Yahoo account turns up during extraction, not just this one. Hardcoding a single league's slug there would be wrong.

## Verification

Ran the dev server and read the rendered DOM on `/this-season` — the only outbound Yahoo link in the app now resolves to `https://football.fantasysports.yahoo.com/league/oakdale_park`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)